### PR TITLE
feat: replace Adobe Typekit with Google Fonts Inter

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -136,7 +136,7 @@ audio:not([controls]),
   }
 }
 body {
-  font-family: 'calluna-sans', sans-serif;
+  font-family: 'Inter', sans-serif;
   font-weight: 400;
   font-size: 16px;
 }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,6 +38,7 @@ const siteTitle = title === SITE.title ? title : `${title} | ${SITE.title}`;
     <link rel="alternate" href="/feed.xml" type="application/rss+xml" title={SITE.description} />
     
     <!-- Google Fonts -->
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700;900&display=swap" rel="stylesheet">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,7 +38,6 @@ const siteTitle = title === SITE.title ? title : `${title} | ${SITE.title}`;
     <link rel="alternate" href="/feed.xml" type="application/rss+xml" title={SITE.description} />
     
     <!-- Google Fonts -->
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700;900&display=swap" rel="stylesheet">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,23 +37,17 @@ const siteTitle = title === SITE.title ? title : `${title} | ${SITE.title}`;
     <!-- RSS -->
     <link rel="alternate" href="/feed.xml" type="application/rss+xml" title={SITE.description} />
     
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700;900&display=swap" rel="stylesheet">
+    
     <!-- Styles -->
     <link rel="stylesheet" href="/css/main.css" />
     
     <!-- Favicons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    
-    <!-- Typekit -->
-    <script>
-      (function() {
-        var config = {
-          kitId: 'urs6cvc',
-          scriptTimeout: 3000
-        };
-        var h=document.getElementsByTagName("html")[0];h.className+=" wf-loading";var t=setTimeout(function(){h.className=h.className.replace(/(\s|^)wf-loading(\s|$)/g," ");h.className+=" wf-inactive"},config.scriptTimeout);var tk=document.createElement("script"),d=false;tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.type="text/javascript";tk.async="true";tk.onload=tk.onreadystatechange=function(){var a=this.readyState;if(d||a&&a!="complete"&&a!="loaded")return;d=true;clearTimeout(t);try{Typekit.load(config)}catch(b){}};var s=document.getElementsByTagName("script")[0];s.parentNode.insertBefore(tk,s)
-      })();
-    </script>
   </head>
   <body>
     <header class="page-header">


### PR DESCRIPTION
Replaces Adobe Typekit with Google Fonts Inter to eliminate dependency on inactive Creative Cloud subscription.

## Changes
- Remove Typekit script from BaseLayout.astro
- Add Google Fonts Inter with preconnect optimization
- Update CSS font-family from 'calluna-sans' to 'Inter'
- Include multiple font weights for design flexibility

Resolves #27

Generated with [Claude Code](https://claude.ai/code)