### PR TITLE
feat: migrate to Google Analytics 4

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,4 +7,5 @@ export const SITE = {
   twitter: '@bendrucker',
   twitterUrl: 'https://twitter.com/bendrucker',
   github: 'https://github.com/bendrucker/bendrucker.me',
+  googleAnalyticsId: 'G-GDY00493QG',
 } as const;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -44,6 +44,15 @@ const siteTitle = title === SITE.title ? title : `${title} | ${SITE.title}`;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     
+    <!-- Google Analytics 4 -->
+    <script async src={`https://www.googletagmanager.com/gtag/js?id=${SITE.googleAnalyticsId}`}></script>
+    <script define:vars={{ gaId: SITE.googleAnalyticsId }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', gaId);
+    </script>
+    
     <!-- Typekit -->
     <script>
       (function() {
@@ -82,19 +91,5 @@ const siteTitle = title === SITE.title ? title : `${title} | ${SITE.title}`;
         </a>
       </div>
     </footer>
-    
-    <!-- Google Analytics (Legacy) - Consider upgrading to GA4 -->
-    <script>
-      // Legacy GA code preserved - recommend upgrading to GA4 for modern tracking
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-37287457-1']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = 'https://ssl.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Migrate from legacy Universal Analytics to Google Analytics 4

- Add GA4 tracking ID (G-GDY00493QG) to site config
- Replace legacy Universal Analytics with GA4 script
- Move analytics to head section for better performance
- Use Astro define:vars for proper variable interpolation

Closes #14

Generated with [Claude Code](https://claude.ai/code)