### PR TITLE
ci: use Astro's official GitHub Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,22 +23,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
-      
-      - name: Install dependencies
-        run: npm ci
-      
-      - name: Build with Astro
-        run: npm run build
-      
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
+      - name: Build site
+        uses: withastro/action@v3
 
   deploy:
     if: github.event_name == 'push' && contains(fromJson('["main", "master"]'), github.ref_name)


### PR DESCRIPTION
Replaces manual Node.js setup, dependency installation, and build steps with `withastro/action@v3`.

## Changes

- Simplified build job from 6 steps to 2 steps
- Uses official Astro action that automatically handles package manager detection, dependency installation, and site building
- Maintains same deployment workflow and functionality

## Benefits

- Reduced maintenance burden
- Official Astro support and updates
- Automatic package manager detection
- Cleaner workflow configuration

Closes #21