### PR TITLE
fix: improve Google search appearance with ICO favicon

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -57,6 +57,7 @@ const structuredData = {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
 


### PR DESCRIPTION
Fixes favicon display issue in Google search results by adding ICO fallback.

## Issue
Google search results showed the Astro logo instead of the personal favicon, likely due to missing ICO format support.

## Changes
- Added ICO favicon link alongside existing SVG favicon for better browser/search engine compatibility

## Testing
- Verified both favicon files exist in static/ directory
- ICO fallback ensures consistent favicon display across all browsers and search engines