### PR TITLE
cloudflare: skip dependabot, name PR builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --assets dist
+          command: deploy --assets dist ${{ github.event_name == 'pull_request' && format('--name bendrucker-me-pr-{0}', github.event.number) || '' }}
 
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   cloudflare:
-    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/' + github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'
     name: Deploy to Cloudflare Workers
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/deploy-pages@v4
 
   cloudflare:
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'master')
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'
     name: Deploy to Cloudflare Workers
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --assets dist ${{ github.event_name == 'pull_request' && format('--name bendrucker-me-pr-{0}', github.event.number) || '' }}
+          gitHubToken: ${{ github.token }}
 
   lighthouse:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevents unnecessary preview deploys when dependabot creates PRs, while using dynamic default branch reference instead of hardcoded master.

## Changes
- Modified cloudflare job condition to exclude dependabot[bot] actor
- Replaced hardcoded 'master' with github.event.repository.default_branch