### PR TITLE
cloudflare: switch to Workers custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,6 @@ concurrency:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
   deployments: write
 
 jobs:
@@ -29,21 +27,6 @@ jobs:
       - name: Build site
         uses: withastro/action@v4
 
-  pages:
-    if: github.event_name == 'push' && contains(fromJson('["main", "master"]'), github.ref_name)
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
 
   cloudflare:
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/' + github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-www.bendrucker.me

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,7 @@ compatibility_date = "2024-07-27"
 
 [assets]
 directory = "dist"
+
+[[routes]]
+pattern = "www.bendrucker.me/*"
+custom_domain = true


### PR DESCRIPTION
Migrates www.bendrucker.me from GitHub Pages to Cloudflare Workers using custom domain routing.

## Changes
- Add custom domain route to `wrangler.toml` for `www.bendrucker.me/*`
- Remove `static/CNAME` file (no longer needed for GitHub Pages)
- Remove GitHub Pages deployment job from Actions workflow
- Remove unnecessary Pages permissions

## Deployment Steps
1. Delete CNAME record `www.bendrucker.me → bendrucker.github.io` in Cloudflare DNS
2. Set up Workers Custom Domain for `www.bendrucker.me` in Cloudflare dashboard
3. Merge this PR

Workers deployment will handle the domain automatically once the Custom Domain is configured.