### PR TITLE
fix: remove wildcard from custom domain pattern

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,5 +6,5 @@ compatibility_date = "2024-07-27"
 directory = "dist"
 
 [[routes]]
-pattern = "www.bendrucker.me/*"
+pattern = "www.bendrucker.me"
 custom_domain = true


### PR DESCRIPTION
Fixes custom domain configuration by removing the wildcard pattern.

Custom domains don't support wildcards (`*`) or paths - only the base domain is allowed.

Changes:
- `www.bendrucker.me/*` → `www.bendrucker.me`