### PR TITLE
fix: split Cloudflare Workers steps and fix syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: ${{ github.event_name == 'pull_request' && format('versions upload --tag "PR-{0}" --message "Preview for PR #{0}: {1}"', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
+          command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR #{0}: {1}"', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
           gitHubToken: ${{ github.token }}
 
   lighthouse:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,12 +53,21 @@ jobs:
       - name: "🚀 Build"
         run: npm run build
 
-      - name: "🌐 Deploy to Cloudflare Workers"
+      - name: "🌐 Upload Cloudflare Workers version"
+        if: github.event_name == 'pull_request'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR #{0}: {1}"', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
+          command: versions upload --tag PR-${{ github.event.number }} --message "Preview for PR #${{ github.event.number }}: ${{ github.event.pull_request.html_url }}"
+          gitHubToken: ${{ github.token }}
+
+      - name: "🌐 Deploy to Cloudflare Workers"
+        if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           gitHubToken: ${{ github.token }}
 
   lighthouse:


### PR DESCRIPTION
Fixes Cloudflare Workers workflow syntax errors and improves clarity by splitting into separate steps.

## Changes

- Split into separate upload and deploy steps for better readability
- Upload version for PRs with proper tag (`PR-{number}`) and message including PR URL
- Deploy to production only for main branch pushes
- Remove explicit `deploy` command since it's the default
- Fix GitHub Actions syntax issues with nested quotes

## Testing

This PR will test the new split workflow structure with proper preview version creation.