### PR TITLE
fix: remove # character to avoid shell interpretation issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --tag PR-${{ github.event.number }} --message "Preview for PR ${{ github.event.number }}: ${{ github.event.pull_request.html_url }}"
+          command: versions upload --tag PR-${{ github.event.number }} --message "Preview for PR ${{ github.event.number }} - ${{ github.event.pull_request.html_url }}"
           gitHubToken: ${{ github.token }}
 
       - name: "🌐 Deploy to Cloudflare Workers"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,12 +56,10 @@ jobs:
       - name: "🌐 Upload Cloudflare Workers version"
         if: github.event_name == 'pull_request'
         uses: cloudflare/wrangler-action@v3
-        env:
-          PR_MESSAGE: "Preview for PR #${{ github.event.number }}: ${{ github.event.pull_request.html_url }}"
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --tag PR-${{ github.event.number }} --message "$PR_MESSAGE"
+          command: versions upload --tag PR-${{ github.event.number }} --message "Preview for PR ${{ github.event.number }}: ${{ github.event.pull_request.html_url }}"
           gitHubToken: ${{ github.token }}
 
       - name: "🌐 Deploy to Cloudflare Workers"


### PR DESCRIPTION
Fixes shell interpretation issues by removing the `#` character from the Cloudflare Workers version message.

## Issue

The `#` character in shell commands is interpreted as a comment delimiter, causing the message to be truncated at that point.

## Solution

Remove the `#` character from the message format, changing from:
```
"Preview for PR #58: [URL]"
```
to:
```
"Preview for PR 58: [URL]"
```

This avoids shell interpretation issues while preserving the PR URL in the message.