### PR TITLE
fix: center appearance toggle in mobile navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -94,7 +94,7 @@ const isActive = (path: string) => {
           }
           {
             SITE.lightAndDarkMode && (
-              <li class="col-span-1 flex items-center justify-center">
+              <li class="col-span-2 flex items-center justify-center">
                 <button
                   id="theme-btn"
                   class="focus-outline relative size-12 p-4 sm:size-8 hover:[&>svg]:stroke-accent"


### PR DESCRIPTION
Fixes the misalignment of the appearance toggle in mobile navigation by changing from `col-span-1` to `col-span-2` to match other menu items.

Closes #62

Generated with [Claude Code](https://claude.ai/code)