### PR TITLE
github: add deployment status support

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,31 @@
+name: Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  deployments: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🧹 Mark PR deployment as inactive"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ENVIRONMENT="pr-${{ github.event.number }}"
+          
+          # Get all deployments for this environment
+          DEPLOYMENTS=$(gh api repos/${{ github.repository }}/deployments \
+            --field environment="$ENVIRONMENT" \
+            --jq '.[].id')
+          
+          # Mark each deployment as inactive
+          for DEPLOYMENT_ID in $DEPLOYMENTS; do
+            gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+              --method POST \
+              --field state=inactive \
+              --field description="PR closed - environment destroyed"
+          done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
       - name: "📍 Create deployment"
         id: create-deployment
         run: |
-          ENVIRONMENT=${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
+          ENVIRONMENT=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
           PRODUCTION=${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
           TRANSIENT=${{ github.event_name == 'pull_request' }}
           

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         id: create-deployment
         env:
           GH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref_name }}
+          REF: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
           ENVIRONMENT: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
           PRODUCTION: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
           TRANSIENT: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,30 +104,6 @@ jobs:
             --field environment_url="${{ steps.wrangler.outputs.deployment-url }}" \
             --field description="$DESCRIPTION"
 
-  cleanup:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      deployments: write
-    steps:
-      - name: "🧹 Mark PR deployment as inactive"
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ENVIRONMENT="pr-${{ github.event.number }}"
-          
-          # Get all deployments for this environment
-          DEPLOYMENTS=$(gh api repos/${{ github.repository }}/deployments \
-            --field environment="$ENVIRONMENT" \
-            --jq '.[].id')
-          
-          # Mark each deployment as inactive
-          for DEPLOYMENT_ID in $DEPLOYMENTS; do
-            gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
-              --method POST \
-              --field state=inactive \
-              --field description="PR closed - environment destroyed"
-          done
 
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,6 @@ jobs:
             --field environment="$ENVIRONMENT" \
             --field production_environment="$PRODUCTION" \
             --field transient_environment="$TRANSIENT" \
-            --raw-field required_contexts='[]' \
             --field auto_merge=false \
             --jq '.id')
           

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
 
   cloudflare:
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'
-    name: Deploy to Cloudflare Workers
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -74,12 +73,12 @@ jobs:
             --field required_contexts[] \
             --field auto_merge=false \
             --jq '.id')
-          
+
           if [ -z "$DEPLOYMENT_ID" ]; then
             echo "Error: Failed to create deployment"
             exit 1
           fi
-          
+
           echo "deployment-id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
 
       - name: "🌐 Deploy to Cloudflare Workers"
@@ -98,12 +97,37 @@ jobs:
         run: |
           STATE=${{ steps.wrangler.outcome == 'success' && 'success' || 'failure' }}
           DESCRIPTION="${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && 'Production deployment to Cloudflare Workers' || format('Preview deployment for PR #{0}', github.event.number) }}"
-          
+
           gh api repos/${{ github.repository }}/deployments/${{ steps.create-deployment.outputs.deployment-id }}/statuses \
             --method POST \
             --field state="$STATE" \
             --field environment_url="${{ steps.wrangler.outputs.deployment-url }}" \
             --field description="$DESCRIPTION"
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+    steps:
+      - name: "🧹 Mark PR deployment as inactive"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ENVIRONMENT="pr-${{ github.event.number }}"
+          
+          # Get all deployments for this environment
+          DEPLOYMENTS=$(gh api repos/${{ github.repository }}/deployments \
+            --field environment="$ENVIRONMENT" \
+            --jq '.[].id')
+          
+          # Mark each deployment as inactive
+          for DEPLOYMENT_ID in $DEPLOYMENTS; do
+            gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+              --method POST \
+              --field state=inactive \
+              --field description="PR closed - environment destroyed"
+          done
 
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,8 @@ jobs:
 
       - name: "📍 Create deployment"
         id: create-deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           ENVIRONMENT=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
           PRODUCTION=${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
@@ -76,7 +78,7 @@ jobs:
           echo "deployment-id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
 
       - name: "🌐 Deploy to Cloudflare Workers"
-        id: deploy
+        id: wrangler
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -86,14 +88,16 @@ jobs:
 
       - name: "📍 Update deployment status"
         if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          STATE=${{ steps.deploy.outcome == 'success' && 'success' || 'failure' }}
+          STATE=${{ steps.wrangler.outcome == 'success' && 'success' || 'failure' }}
           DESCRIPTION="${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && 'Production deployment to Cloudflare Workers' || format('Preview deployment for PR #{0}', github.event.number) }}"
           
           gh api repos/${{ github.repository }}/deployments/${{ steps.create-deployment.outputs.deployment-id }}/statuses \
             --method POST \
             --field state="$STATE" \
-            --field environment_url="${{ steps.deploy.outputs.deployment-url }}" \
+            --field environment_url="${{ steps.wrangler.outputs.deployment-url }}" \
             --field description="$DESCRIPTION"
 
   lighthouse:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,14 +60,14 @@ jobs:
         id: create-deployment
         env:
           GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref_name }}
+          ENVIRONMENT: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
+          PRODUCTION: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
+          TRANSIENT: ${{ github.event_name == 'pull_request' }}
         run: |
-          ENVIRONMENT=${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
-          PRODUCTION=${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
-          TRANSIENT=${{ github.event_name == 'pull_request' }}
-          
           DEPLOYMENT_ID=$(gh api repos/${{ github.repository }}/deployments \
             --method POST \
-            --field ref=${{ github.sha }} \
+            --field ref="$REF" \
             --field environment="$ENVIRONMENT" \
             --field production_environment="$PRODUCTION" \
             --field transient_environment="$TRANSIENT" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,25 @@ jobs:
       - name: "📋 Copy assets ignore file"
         run: cp .assetsignore dist/
 
+      - name: "📍 Create deployment"
+        id: create-deployment
+        run: |
+          ENVIRONMENT=${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
+          PRODUCTION=${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
+          TRANSIENT=${{ github.event_name == 'pull_request' }}
+          
+          DEPLOYMENT_ID=$(gh api repos/${{ github.repository }}/deployments \
+            --method POST \
+            --field ref=${{ github.sha }} \
+            --field environment="$ENVIRONMENT" \
+            --field production_environment="$PRODUCTION" \
+            --field transient_environment="$TRANSIENT" \
+            --field required_contexts='[]' \
+            --field auto_merge=false \
+            --jq '.id')
+          
+          echo "deployment-id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+
       - name: "🌐 Deploy to Cloudflare Workers"
         id: deploy
         uses: cloudflare/wrangler-action@v3
@@ -65,41 +84,17 @@ jobs:
           command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR {0} - {1}"', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
           gitHubToken: ${{ github.token }}
 
-      - name: "📍 Create deployment status"
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
-            
-            if (deploymentUrl) {
-              const isProduction = github.event_name === 'push' && '${{ github.ref_name }}' === '${{ github.event.repository.default_branch }}';
-              const environment = isProduction ? 'production' : 'preview';
-              const description = isProduction 
-                ? 'Production deployment to Cloudflare Workers'
-                : `Preview deployment for PR #${{ github.event.number }}`;
-              
-              // Create deployment
-              const deployment = await github.rest.repos.createDeployment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: context.sha,
-                environment: environment,
-                production_environment: isProduction,
-                transient_environment: !isProduction,
-                required_contexts: [],
-                auto_merge: false
-              });
-              
-              // Create deployment status
-              await github.rest.repos.createDeploymentStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                deployment_id: deployment.data.id,
-                state: 'success',
-                environment_url: deploymentUrl,
-                description: description
-              });
-            }
+      - name: "📍 Update deployment status"
+        if: always()
+        run: |
+          STATE=${{ steps.deploy.outcome == 'success' && 'success' || 'failure' }}
+          DESCRIPTION="${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && 'Production deployment to Cloudflare Workers' || format('Preview deployment for PR #{0}', github.event.number) }}"
+          
+          gh api repos/${{ github.repository }}/deployments/${{ steps.create-deployment.outputs.deployment-id }}/statuses \
+            --method POST \
+            --field state="$STATE" \
+            --field environment_url="${{ steps.deploy.outputs.deployment-url }}" \
+            --field description="$DESCRIPTION"
 
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,11 @@ jobs:
             --field auto_merge=false \
             --jq '.id')
           
+          if [ -z "$DEPLOYMENT_ID" ]; then
+            echo "Error: Failed to create deployment"
+            exit 1
+          fi
+          
           echo "deployment-id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
 
       - name: "🌐 Deploy to Cloudflare Workers"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
             --field environment="$ENVIRONMENT" \
             --field production_environment="$PRODUCTION" \
             --field transient_environment="$TRANSIENT" \
-            --field required_contexts='[]' \
+            --raw-field required_contexts='[]' \
             --field auto_merge=false \
             --jq '.id')
           

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,22 +56,50 @@ jobs:
       - name: "📋 Copy assets ignore file"
         run: cp .assetsignore dist/
 
-      - name: "🌐 Upload Cloudflare Workers version"
-        if: github.event_name == 'pull_request'
+      - name: "🌐 Deploy to Cloudflare Workers"
+        id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --tag PR-${{ github.event.number }} --message "Preview for PR ${{ github.event.number }} - ${{ github.event.pull_request.html_url }}"
+          command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR {0} - {1}"', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
           gitHubToken: ${{ github.token }}
 
-      - name: "🌐 Deploy to Cloudflare Workers"
-        if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
-        uses: cloudflare/wrangler-action@v3
+      - name: "📍 Create deployment status"
+        uses: actions/github-script@v7
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          gitHubToken: ${{ github.token }}
+          script: |
+            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
+            
+            if (deploymentUrl) {
+              const isProduction = github.event_name === 'push' && '${{ github.ref_name }}' === '${{ github.event.repository.default_branch }}';
+              const environment = isProduction ? 'production' : 'preview';
+              const description = isProduction 
+                ? 'Production deployment to Cloudflare Workers'
+                : `Preview deployment for PR #${{ github.event.number }}`;
+              
+              // Create deployment
+              const deployment = await github.rest.repos.createDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: context.sha,
+                environment: environment,
+                production_environment: isProduction,
+                transient_environment: !isProduction,
+                required_contexts: [],
+                auto_merge: false
+              });
+              
+              // Create deployment status
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.data.id,
+                state: 'success',
+                environment_url: deploymentUrl,
+                description: description
+              });
+            }
 
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ jobs:
             --field environment="$ENVIRONMENT" \
             --field production_environment="$PRODUCTION" \
             --field transient_environment="$TRANSIENT" \
+            --field required_contexts[] \
             --field auto_merge=false \
             --jq '.id')
           
@@ -91,7 +92,7 @@ jobs:
           gitHubToken: ${{ github.token }}
 
       - name: "📍 Update deployment status"
-        if: always()
+        if: always() && steps.create-deployment.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
Adds GitHub Deployments support to the deploy workflow by capturing the `deployment-url` output from wrangler-action and creating deployment status entries.

## Changes

- Combines separate Cloudflare deployment steps into single step with conditional command
- Adds deployment status creation using GitHub's Deployments API
- Marks preview deployments as transient environments
- Creates appropriate environment URLs for both production and preview deployments