### PR TITLE
github: fix cleanup workflow deployment query

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -20,6 +20,7 @@ jobs:
           # Get all deployments for this environment
           DEPLOYMENTS=$(gh api repos/${{ github.repository }}/deployments \
             --field environment="$ENVIRONMENT" \
+            --field ref="${{ github.event.pull_request.head.ref }}" \
             --jq '.[].id')
           
           # Mark each deployment as inactive


### PR DESCRIPTION
Fixes the cleanup workflow that was failing with "ref wasn't supplied" error.

## Changes

- Add `ref` parameter to deployment query using `github.event.pull_request.head.ref`
- This allows the API to find deployments for the specific PR branch/environment combination