### PR TITLE
github: fix cleanup workflow with explicit GET method

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -19,6 +19,7 @@ jobs:
           
           # Get all deployments for this environment
           DEPLOYMENTS=$(gh api repos/${{ github.repository }}/deployments \
+            --method GET \
             --field environment="$ENVIRONMENT" \
             --field ref="${{ github.event.pull_request.head.ref }}" \
             --jq '.[].id')


### PR DESCRIPTION
Fixes the cleanup workflow by adding explicit `--method GET` to the deployment query.

## Issue

When using `--field` parameters with `gh api`, it defaults to POST method, which was causing 409 conflicts when trying to query deployments.

## Fix

- Add `--method GET` to explicitly use GET method for querying deployments
- This allows the environment and ref filtering to work correctly