### PR TITLE
docs: update deployment info to Cloudflare Workers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,7 +212,7 @@ Ready for future interactivity with vanilla JavaScript or modern web APIs.
 - **Static HTML**: Pre-rendered at build time
 - **Minimal JS**: Vanilla JavaScript for essential interactivity
 - **CSS**: Single file, optimized loading
-- **Images**: Served from CDN (GitHub Pages)
+- **Images**: Served from CDN (Cloudflare Workers)
 
 ### SEO Features
 - **Meta tags**: Complete Open Graph and Twitter Cards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This is a personal website and blog built with modern web technologies, migrated
 - **Styling**: [TailwindCSS](https://tailwindcss.com) - Utility-first CSS framework
 - **Styling**: CSS (compiled from original Stylus) with modern web standards
 - **Content**: Markdown files with frontmatter, managed through Astro content collections
-- **Deployment**: GitHub Actions → GitHub Pages
+- **Deployment**: GitHub Actions → Cloudflare Workers
 - **Domain**: www.bendrucker.me
 
 ### Key Design Principles
@@ -141,7 +141,7 @@ git remote add upstream https://github.com/satnaing/astro-paper.git
 
 ### Automatic Deployment
 - **Trigger**: Push to `master` branch
-- **Process**: GitHub Actions builds and deploys to GitHub Pages
+- **Process**: GitHub Actions builds and deploys to Cloudflare Workers
 - **URL**: Automatically available at www.bendrucker.me
 
 ### Manual Deployment

--- a/readme.md
+++ b/readme.md
@@ -8,28 +8,31 @@ Personal website and blog built with [Astro](https://astro.build).
 
 - **Framework**: Astro (static site generation)
 - **Styling**: TailwindCSS
-- **Styling**: CSS (compiled from Stylus)
-- **Content**: Markdown with frontmatter
+- **Content**: Markdown with frontmatter (content collections)
+- **Image Generation**: Dynamic OG images and RSS feed
 - **Deployment**: GitHub Actions → GitHub Pages
 
 ## 📁 Project Structure
 
 ```text
 /
-├── public/              # Static assets (images, fonts, CSS)
+├── static/             # Source static assets (copied to public/ during build)
+├── public/             # Build output directory for static assets
+├── dist/               # Production build output
 ├── src/
 │   ├── content/
-│   │   └── blog/       # Blog posts (Markdown)
-│   ├── layouts/        # Astro layout components
-│   ├── pages/          # Routes (.astro files)
-│   └── config.ts       # Site configuration
-├── .github/workflows/  # GitHub Actions for deployment
+│   │   └── blog/      # Blog posts (Markdown with content collections)
+│   ├── layouts/       # Astro layout components
+│   ├── pages/         # Routes (.astro files)
+│   ├── components/    # Reusable Astro components
+│   └── config.ts      # Site configuration
+├── .github/workflows/ # GitHub Actions for deployment
 └── package.json
 ```
 
-- **Content Collections**: Blog posts are managed through Astro's content collections
-- **Layouts**: Reusable page layouts with proper SEO and meta tags
-- **Static Assets**: Images, fonts, and compiled CSS in `public/`
+- **Content Collections**: Blog posts managed through Astro's type-safe content collections
+- **Static Assets**: Source files in `static/`, build output in `public/`
+- **Components**: Reusable Astro components with proper TypeScript typing
 
 ## 🧞 Commands
 
@@ -56,7 +59,7 @@ The site is built with modern web standards and includes:
 
 ## 🚀 Deployment
 
-The site automatically deploys to GitHub Pages when changes are pushed to the main branch. The deployment process:
+The site automatically deploys to GitHub Pages when changes are pushed to the master branch. The deployment process:
 
 1. **Build**: Astro generates static files in `./dist/`
 2. **Deploy**: GitHub Actions uploads to GitHub Pages


### PR DESCRIPTION
Updates documentation to reflect current deployment setup and fixes outdated tech stack information.

## Changes
- Update deployment info from GitHub Pages to Cloudflare Workers in both README.md and CLAUDE.md
- Remove obsolete Stylus reference, now uses TailwindCSS only
- Fix project structure to show static/ for source assets, public/ for build output
- Add missing tech stack components (OG images, RSS feed)
- Remove broken MIGRATION.md link from README