### PR TITLE
github: simplify deployments with action

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,4 +16,5 @@ jobs:
         with:
           step: deactivate-env
           token: ${{ github.token }}
+          ref: ${{ github.head_ref || github.ref_name }}
           env: pr-${{ github.event.number }}

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -12,22 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "🧹 Mark PR deployment as inactive"
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ENVIRONMENT="pr-${{ github.event.number }}"
-          
-          # Get all deployments for this environment
-          DEPLOYMENTS=$(gh api repos/${{ github.repository }}/deployments \
-            --method GET \
-            --field environment="$ENVIRONMENT" \
-            --field ref="${{ github.event.pull_request.head.ref }}" \
-            --jq '.[].id')
-          
-          # Mark each deployment as inactive
-          for DEPLOYMENT_ID in $DEPLOYMENTS; do
-            gh api repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
-              --method POST \
-              --field state=inactive \
-              --field description="PR closed - environment destroyed"
-          done
+        uses: bobheadxi/deployments@v1
+        with:
+          step: deactivate-env
+          token: ${{ github.token }}
+          env: pr-${{ github.event.number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
           status: ${{ steps.wrangler.outcome }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ github.event_name == 'pull_request' && format('https://pr-{0}.bendrucker.me', github.event.number) || steps.wrangler.outputs.deployment-url }}
+          env_url: ${{ steps.wrangler.outputs.deployment-url }}
 
 
   lighthouse:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,13 @@ jobs:
           command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR {0} - {1}" --compatibility-date 2024-09-23 --preview-alias pr-{0}', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
           gitHubToken: ${{ github.token }}
 
+      - name: "🔗 Extract alias URL"
+        id: extract-url
+        if: github.event_name == 'pull_request'
+        run: |
+          ALIAS_URL=$(echo "${{ steps.wrangler.outputs.command-output }}" | grep -o "Version Preview Alias URL: https://[^[:space:]]*" | sed 's/Version Preview Alias URL: //' | xargs)
+          echo "alias-url=$ALIAS_URL" >> $GITHUB_OUTPUT
+
       - name: "📍 Finish deployment"
         if: always() && steps.deployment.outcome == 'success'
         uses: bobheadxi/deployments@v1
@@ -84,7 +91,7 @@ jobs:
           status: ${{ steps.wrangler.outcome }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ steps.wrangler.outputs.deployment-url }}
+          env_url: ${{ github.event_name == 'pull_request' && steps.extract-url.outputs.alias-url || steps.wrangler.outputs.deployment-url }}
 
 
   lighthouse:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
         id: extract-url
         if: github.event_name == 'pull_request'
         run: |
-          ALIAS_URL=$(echo "${{ steps.wrangler.outputs.command-output }}" | grep -o "Version Preview Alias URL: https://[^[:space:]]*" | sed 's/Version Preview Alias URL: //' | xargs)
+          ALIAS_URL=$(echo "${{ steps.wrangler.outputs.command-output }}" | sed -n 's/.*Version Preview Alias URL: //p' | xargs)
           echo "alias-url=$ALIAS_URL" >> $GITHUB_OUTPUT
 
       - name: "📍 Finish deployment"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR {0} - {1}"', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
+          command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR {0} - {1}" --compatibility-date 2024-09-23 --preview-alias pr-{0}', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
           gitHubToken: ${{ github.token }}
 
       - name: "📍 Finish deployment"
@@ -84,7 +84,7 @@ jobs:
           status: ${{ steps.wrangler.outcome }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ steps.wrangler.outputs.deployment-url }}
+          env_url: ${{ github.event_name == 'pull_request' && format('https://pr-{0}.bendrucker.me', github.event.number) || steps.wrangler.outputs.deployment-url }}
 
 
   lighthouse:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           step: finish
           token: ${{ github.token }}
+          ref: ${{ github.head_ref || github.ref_name }}
           status: ${{ steps.wrangler.outcome }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
           step: start
           token: ${{ github.token }}
           env: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
-          desc: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && 'Production deployment to Cloudflare Workers' || format('Preview deployment for PR #{0}', github.event.number) }}
+          desc: ${{ github.event_name == 'pull_request' && format('Preview deployment for PR #{0}', github.event.number) || 'Production deployment to Cloudflare Workers' }}
 
       - name: "🌐 Deploy to Cloudflare Workers"
         id: wrangler

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
           step: start
           token: ${{ github.token }}
           env: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
-          desc: ${{ github.event_name == 'pull_request' && format('Preview deployment for PR #{0}', github.event.number) || 'Production deployment to Cloudflare Workers' }}
+          desc: ${{ github.event_name == 'pull_request' && format('Preview deployment for PR {0}', github.event.number) || 'Production deployment to Cloudflare Workers' }}
 
       - name: "🌐 Deploy to Cloudflare Workers"
         id: wrangler

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           step: start
           token: ${{ github.token }}
+          ref: ${{ github.head_ref || github.ref_name }}
           env: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
           desc: ${{ github.event_name == 'pull_request' && format('Preview deployment for PR {0}', github.event.number) || 'Production deployment to Cloudflare Workers' }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,31 +55,14 @@ jobs:
       - name: "📋 Copy assets ignore file"
         run: cp .assetsignore dist/
 
-      - name: "📍 Create deployment"
-        id: create-deployment
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REF: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-          ENVIRONMENT: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
-          PRODUCTION: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
-          TRANSIENT: ${{ github.event_name == 'pull_request' }}
-        run: |
-          DEPLOYMENT_ID=$(gh api repos/${{ github.repository }}/deployments \
-            --method POST \
-            --field ref="$REF" \
-            --field environment="$ENVIRONMENT" \
-            --field production_environment="$PRODUCTION" \
-            --field transient_environment="$TRANSIENT" \
-            --field required_contexts[] \
-            --field auto_merge=false \
-            --jq '.id')
-
-          if [ -z "$DEPLOYMENT_ID" ]; then
-            echo "Error: Failed to create deployment"
-            exit 1
-          fi
-
-          echo "deployment-id=$DEPLOYMENT_ID" >> $GITHUB_OUTPUT
+      - name: "📍 Start deployment"
+        id: deployment
+        uses: bobheadxi/deployments@v1
+        with:
+          step: start
+          token: ${{ github.token }}
+          env: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || 'production' }}
+          desc: ${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && 'Production deployment to Cloudflare Workers' || format('Preview deployment for PR #{0}', github.event.number) }}
 
       - name: "🌐 Deploy to Cloudflare Workers"
         id: wrangler
@@ -90,19 +73,16 @@ jobs:
           command: ${{ github.event_name == 'pull_request' && format('versions upload --tag PR-{0} --message "Preview for PR {0} - {1}"', github.event.number, github.event.pull_request.html_url) || 'deploy' }}
           gitHubToken: ${{ github.token }}
 
-      - name: "📍 Update deployment status"
-        if: always() && steps.create-deployment.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          STATE=${{ steps.wrangler.outcome == 'success' && 'success' || 'failure' }}
-          DESCRIPTION="${{ github.event_name == 'push' && github.ref_name == github.event.repository.default_branch && 'Production deployment to Cloudflare Workers' || format('Preview deployment for PR #{0}', github.event.number) }}"
-
-          gh api repos/${{ github.repository }}/deployments/${{ steps.create-deployment.outputs.deployment-id }}/statuses \
-            --method POST \
-            --field state="$STATE" \
-            --field environment_url="${{ steps.wrangler.outputs.deployment-url }}" \
-            --field description="$DESCRIPTION"
+      - name: "📍 Finish deployment"
+        if: always() && steps.deployment.outcome == 'success'
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ github.token }}
+          status: ${{ steps.wrangler.outcome }}
+          env: ${{ steps.deployment.outputs.env }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ steps.wrangler.outputs.deployment-url }}
 
 
   lighthouse:


### PR DESCRIPTION
Use `bobheadxi/deployments` action rather than struggling with direct CLI-driven `gh api` calls.