### PR TITLE
typescript: enable noImplicitAny to prevent usage of any type

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "types": ["node"],
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
Enables the `noImplicitAny` TypeScript compiler option to prevent usage of the `any` type. This ensures all variables and function parameters have explicit types, improving type safety and catching potential errors at compile time.

## Changes
- Added `"noImplicitAny": true` to `tsconfig.json`
- Verified no existing `any` usage in source code
- Confirmed build passes with strict type checking