### PR TITLE
fix: access KV bindings through Astro.locals.runtime.env

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -38,6 +38,9 @@ export default defineConfig({
   output: "server",
   adapter: cloudflare({
     imageService: "compile",
+    platformProxy: {
+      enabled: true,
+    },
   }),
   integrations: [
     sitemap({

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="astro/client" />
+
+type ENV = {
+  GITHUB_KV: KVNamespace;
+  ASSETS: Fetcher;
+};
+
+type Runtime = import("@astrojs/cloudflare").Runtime<ENV>;
+
+declare namespace App {
+  interface Locals extends Runtime {}
+}

--- a/src/pages/activity/code.astro
+++ b/src/pages/activity/code.astro
@@ -12,15 +12,15 @@ import Star from "@/assets/icons/star.svg";
 import Checklist from "@/assets/icons/checklist.svg";
 import GitMerge from "@/assets/icons/git-merge.svg";
 
-// Type declaration for Cloudflare Workers KV
-declare const GITHUB_KV: KVNamespace | undefined;
-
 // Load activity data
 let repositories: RepoActivity[] = [];
-const isDev = typeof GITHUB_KV === 'undefined';
+let isDev = false;
 
 try {
-  if (typeof GITHUB_KV !== 'undefined') {
+  // Access KV through Astro.locals.runtime.env (correct pattern)
+  const { GITHUB_KV } = Astro.locals.runtime.env;
+  
+  if (GITHUB_KV) {
     // Production: read from KV storage
     const kvData = await GITHUB_KV.get('activity', 'json') as RepoActivity[] | null;
     if (kvData) {
@@ -32,6 +32,7 @@ try {
     }
   } else {
     // Development: try to load from local file
+    isDev = true;
     const localDataPath = join(process.cwd(), 'tmp', 'github-activity.json');
     if (existsSync(localDataPath)) {
       const localData = JSON.parse(readFileSync(localDataPath, 'utf-8')) as RepoActivity[];

--- a/src/pages/debug-kv.astro
+++ b/src/pages/debug-kv.astro
@@ -1,0 +1,29 @@
+---
+// Debug page to test KV access - access through Astro.locals.runtime.env
+const { GITHUB_KV } = Astro.locals.runtime.env;
+
+let result = '';
+try {
+  if (!GITHUB_KV) {
+    result = 'GITHUB_KV binding is not available';
+  } else {
+    const data = await GITHUB_KV.get('activity');
+    if (data) {
+      const parsed = JSON.parse(data);
+      result = `Found ${parsed.length} repositories in KV`;
+    } else {
+      result = 'KV binding exists but no activity data found';
+    }
+  }
+} catch (error) {
+  result = `Error: ${error instanceof Error ? error.message : 'Unknown error'}`;
+}
+---
+
+<html>
+<head><title>KV Debug</title></head>
+<body>
+  <h1>KV Debug</h1>
+  <p>{result}</p>
+</body>
+</html>


### PR DESCRIPTION
Fixes the issue where the main site couldn't access GitHub activity data from the shared KV namespace.

## Issue

The main site at www.bendrucker.me/activity/code was showing "no data" despite the GitHub worker successfully writing activity data to the shared KV namespace. The root cause was that KV bindings were being accessed incorrectly in Astro pages.

## Changes

- Updates activity page to access KV bindings through `Astro.locals.runtime.env` instead of as global variables
- Adds TypeScript environment definitions for proper KV binding types
- Enables `platformProxy` in Astro Cloudflare adapter configuration for local development
- Adds debug page to verify KV binding access

## Testing

After deployment, verify:
- www.bendrucker.me/activity/code shows GitHub activity data
- www.bendrucker.me/debug-kv confirms KV binding is accessible