### PR TITLE
fix: format deployment URL with https:// scheme

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,14 @@ jobs:
           ALIAS_URL=$(echo "${{ steps.wrangler.outputs.command-output }}" | sed -n 's/.*Version Preview Alias URL: //p' | xargs)
           echo "alias-url=$ALIAS_URL" >> $GITHUB_OUTPUT
 
+      - name: "🔗 Extract deployment URL"
+        id: extract-deployment-url
+        if: github.event_name == 'push' && matrix.path == '.'
+        run: |
+          # Extract the custom domain from deployment-url and format as proper URL
+          DEPLOYMENT_URL=$(echo "${{ steps.wrangler.outputs.deployment-url }}" | sed 's/ (custom domain)//' | sed 's/^/https:\/\//')
+          echo "formatted-url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+
       - name: "📍 Finish deployment"
         if: always() && steps.deployment.outcome == 'success'
         uses: bobheadxi/deployments@v1
@@ -108,7 +116,7 @@ jobs:
           status: ${{ steps.wrangler.outcome == 'success' && 'success' || 'failure' }}
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ github.event_name == 'pull_request' && matrix.path == '.' && steps.extract-url.outputs.alias-url || steps.wrangler.outputs.deployment-url }}
+          env_url: ${{ github.event_name == 'pull_request' && matrix.path == '.' && steps.extract-url.outputs.alias-url || (matrix.path == '.' && steps.extract-deployment-url.outputs.formatted-url || steps.wrangler.outputs.deployment-url) }}
 
 
   lighthouse:


### PR DESCRIPTION
Fixes deployment status issue where GitHub API requires proper URL scheme for deployment status updates.

## Issue

The deployment workflow fails at the "Finish deployment" step with error:
```
environment_url must use http(s) scheme
```

Wrangler outputs `www.bendrucker.me (custom domain)` but GitHub's deployment API requires a properly formatted URL like `https://www.bendrucker.me`.

## Changes

- Add step to extract and format deployment URL for production deployments
- Strip `(custom domain)` suffix from Wrangler output
- Prepend `https://` protocol to create valid URL
- Use formatted URL in deployment status for main site deployments only

## Testing

This PR will test the fix by triggering the deployment workflow and verifying the deployment status completes successfully.