### PR TITLE
feat: add Alpine.js for modern client-side components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
         "workers/*"
       ],
       "dependencies": {
+        "@alpinejs/persist": "^3.14.9",
         "@astrojs/cloudflare": "^12.6.0",
         "@astrojs/rss": "^4.0.12",
         "@astrojs/sitemap": "^3.4.2",
         "@resvg/resvg-wasm": "^2.6.2",
         "@tailwindcss/vite": "^4.1.11",
         "@types/node": "^24.1.0",
+        "alpinejs": "^3.14.9",
         "astro": "^5.12.8",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
@@ -48,6 +50,12 @@
         "typescript-eslint": "^8.36.0",
         "wrangler": "^4.27.0"
       }
+    },
+    "node_modules/@alpinejs/persist": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@alpinejs/persist/-/persist-3.14.9.tgz",
+      "integrity": "sha512-Td9hWEUtFFguYCRjXhq06sDultW21wXUnVro7YWJm+vjGu/nV/v3hepOXyYVjkGvH/F+zjx5UkzWXXzr3UiQ/w==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -3595,6 +3603,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vue/reactivity": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
+      "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.1.5"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
+      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+      "license": "MIT"
+    },
     "node_modules/@workspace/github": {
       "resolved": "packages/github",
       "link": true
@@ -3687,6 +3710,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/alpinejs": {
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.14.9.tgz",
+      "integrity": "sha512-gqSOhTEyryU9FhviNqiHBHzgjkvtukq9tevew29fTj+ofZtfsYriw4zPirHHOAy9bw8QoL3WGhyk7QqCh5AYlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "~3.1.1"
       }
     },
     "node_modules/ansi-align": {

--- a/package.json
+++ b/package.json
@@ -20,12 +20,14 @@
     "fetch-activity": "tsx scripts/fetch-github-activity.ts"
   },
   "dependencies": {
+    "@alpinejs/persist": "^3.14.9",
     "@astrojs/cloudflare": "^12.6.0",
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.4.2",
     "@resvg/resvg-wasm": "^2.6.2",
     "@tailwindcss/vite": "^4.1.11",
     "@types/node": "^24.1.0",
+    "alpinejs": "^3.14.9",
     "astro": "^5.12.8",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -134,6 +134,14 @@ const structuredData = {
 
     <script is:inline src="/toggle-theme.js"></script>
   </head>
+  
+  <script>
+    import Alpine from 'alpinejs';
+    import persist from '@alpinejs/persist';
+    
+    Alpine.plugin(persist);
+    Alpine.start();
+  </script>
   <body>
     <Header />
     <slot />


### PR DESCRIPTION
This PR introduces Alpine.js to modernize client-side JavaScript components and enable better timezone handling.

## Changes

- Install Alpine.js and persist plugin for reactive state management
- Set up Alpine.js initialization in the main layout
- Prepare foundation for converting existing vanilla JS to Alpine.js

## Next Steps

This sets up the foundation for follow-up PRs that will:
- Convert timezone handling to use user's local timezone
- Modernize theme switcher with Alpine.js
- Replace vanilla JavaScript with reactive Alpine.js components

## Testing

- [x] Alpine.js loads correctly
- [x] Build passes
- [x] No existing functionality broken