### PR TITLE
Add ESLint to CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,18 @@ permissions:
   deployments: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+
   cloudflare:
     name: ${{ matrix.name }}
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
ESLint is configured but was not running in CI. Unused variables and other lint issues in Astro frontmatter went undetected.

## Changes

Add a `lint` job to the deploy workflow that runs `npm run lint` in parallel with the existing Cloudflare deploy matrix.
