### PR TITLE
Add Prettier formatting and build caching to stop hook

### DIFF
--- a/.claude/hooks/verify.sh
+++ b/.claude/hooks/verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Stop hook: verify lint and build pass before Claude finishes its turn.
+# Stop hook: verify formatting, lint, and build pass before Claude finishes its turn.
 # Exit 2 blocks Claude from stopping and forces it to fix issues.
 
 set -uo pipefail
@@ -21,12 +21,40 @@ fi
 
 errors=""
 
+# Format only changed files that still exist on disk
+changed_existing=$(echo "$changed" | while read -r f; do [ -f "$f" ] && echo "$f"; done | sort -u)
+if [[ -n "$changed_existing" ]]; then
+  npx prettier --write --ignore-unknown $changed_existing >/dev/null 2>&1
+  formatted=$(git diff --name-only)
+  if [[ -n "$formatted" ]]; then
+    errors+="Prettier formatted files:\n${formatted}\n\nStage and commit the formatting changes.\n\n"
+  fi
+fi
+
 if ! lint_output=$(npx eslint . 2>&1); then
   errors+="ESLint errors:\n${lint_output}\n\n"
 fi
 
+# Skip build if source files haven't changed since last successful build
+build_marker="/tmp/claude-stop-hook-build-$(echo "$cwd" | md5sum | cut -d' ' -f1)"
+newest_source=$(git ls-files -- '*.ts' '*.js' '*.mjs' '*.cjs' '*.astro' '*.md' '*.css' | xargs stat -f '%m' 2>/dev/null | sort -rn | head -1)
+
+if [[ -f "$build_marker" ]] && [[ -n "$newest_source" ]]; then
+  marker_time=$(stat -f '%m' "$build_marker")
+  if [[ "$newest_source" -le "$marker_time" ]]; then
+    # No source files changed since last successful build
+    if [[ -n "$errors" ]]; then
+      printf '%b' "$errors" >&2
+      exit 2
+    fi
+    exit 0
+  fi
+fi
+
 if ! build_output=$(npm run build 2>&1); then
   errors+="Build errors:\n${build_output}\n\n"
+else
+  touch "$build_marker"
 fi
 
 if [[ -n "$errors" ]]; then


### PR DESCRIPTION
Extends the stop hook (`verify.sh`) with Prettier auto-formatting on changed files and build result caching to avoid redundant rebuilds.

## Changes

- Run `prettier --write --ignore-unknown` on changed files that still exist on disk, reporting any formatting changes back to Claude for staging
- Cache build results using a `/tmp` marker file keyed by project directory — skips the full build (`build:packages`, `types:generate`, `astro check`, `astro build`) when no tracked source files have been modified since the last successful build
- ESLint continues to run on all files for correctness
