### PR TITLE
feat: split truncated contribution windows into smaller time ranges

### DIFF
--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -50,6 +50,7 @@ export interface RateLimit {
 export interface GitHubActivityResult {
   repos: RepoActivity[];
   rateLimit: RateLimit;
+  truncated: boolean;
 }
 
 // Simple gql tag for syntax highlighting
@@ -338,6 +339,8 @@ export async function fetchGitHubActivity(
       { name: "mergedPRSearch", count: mergedPRSearch?.nodes?.length ?? 0 },
     ];
 
+    const truncated = truncationChecks.some((check) => check.count >= 100);
+
     for (const check of truncationChecks) {
       if (check.count >= 100) {
         logger.warn(
@@ -376,7 +379,7 @@ export async function fetchGitHubActivity(
       "GitHub activity processing completed",
     );
 
-    return { repos: result, rateLimit };
+    return { repos: result, rateLimit, truncated };
   } catch (error) {
     if (error instanceof Error) {
       logger.error(


### PR DESCRIPTION
`contributionsCollection` fields use `maxRepositories: 100` with no cursor pagination. Years 2014-2016 and 2018-2019 hit this limit, losing repo data. This adds truncation detection and automatic bisection to fetch complete data.

## Changes

- Add `truncated: boolean` to `GitHubActivityResult` in `packages/github/src/index.ts`, set when any field hits 100
- Add `fetchWithSplitting()` to `scripts/backfill-github-activity.ts` that recursively bisects time windows when truncation is detected (floor: 1 month)
- Add `mergeRepos()` to deduplicate repos across split windows, keeping latest `lastActivity` and summing activity counts
