### PR TITLE
feat: make year rail ellipses clickable to expand

### DIFF
--- a/src/components/activity/TimelineRail.vue
+++ b/src/components/activity/TimelineRail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import type { YearCount } from "./composables/useActivityApi";
 
 const MAX_VISIBLE = 7;
@@ -14,9 +14,9 @@ const emit = defineEmits<{
   navigate: [year: number];
 }>();
 
-const visibleYears = computed(() => {
-  if (props.years.length <= MAX_VISIBLE) return props.years;
+const expanded = ref(false);
 
+const windowedYears = computed(() => {
   const currentIdx = props.years.findIndex((y) => y.year === props.currentYear);
   const center = currentIdx >= 0 ? currentIdx : 0;
   const half = Math.floor(MAX_VISIBLE / 2);
@@ -31,16 +31,21 @@ const visibleYears = computed(() => {
   return props.years.slice(start, end);
 });
 
+const visibleYears = computed(() => {
+  if (expanded.value || props.years.length <= MAX_VISIBLE) return props.years;
+  return windowedYears.value;
+});
+
 const hasOlderYears = computed(() => {
-  if (props.years.length <= MAX_VISIBLE) return false;
-  const last = visibleYears.value[visibleYears.value.length - 1];
+  if (expanded.value || props.years.length <= MAX_VISIBLE) return false;
+  const last = windowedYears.value[windowedYears.value.length - 1];
   const allLast = props.years[props.years.length - 1];
   return last && allLast && last.year > allLast.year;
 });
 
 const hasNewerYears = computed(() => {
-  if (props.years.length <= MAX_VISIBLE) return false;
-  const first = visibleYears.value[0];
+  if (expanded.value || props.years.length <= MAX_VISIBLE) return false;
+  const first = windowedYears.value[0];
   const allFirst = props.years[0];
   return first && allFirst && first.year < allFirst.year;
 });
@@ -55,9 +60,14 @@ const hasNewerYears = computed(() => {
     <div
       class="sticky top-1/2 -translate-y-1/2 flex flex-col items-end gap-1 h-fit"
     >
-      <span v-if="hasNewerYears" class="text-sm text-foreground/20 px-1.5"
-        >&hellip;</span
+      <button
+        v-if="hasNewerYears"
+        class="text-sm text-foreground/20 hover:text-foreground/40 transition-colors px-1.5"
+        aria-label="Show all years"
+        @click="expanded = true"
       >
+        &hellip;
+      </button>
       <template v-for="y in visibleYears" :key="y.year">
         <button
           v-if="loadedYears.has(y.year)"
@@ -84,9 +94,14 @@ const hasNewerYears = computed(() => {
           {{ y.year }}
         </a>
       </template>
-      <span v-if="hasOlderYears" class="text-sm text-foreground/20 px-1.5"
-        >&hellip;</span
+      <button
+        v-if="hasOlderYears"
+        class="text-sm text-foreground/20 hover:text-foreground/40 transition-colors px-1.5"
+        aria-label="Show all years"
+        @click="expanded = true"
       >
+        &hellip;
+      </button>
     </div>
   </nav>
 </template>


### PR DESCRIPTION
The year rail in `TimelineRail.vue` shows ellipses when there are more than 7 years, but they weren't interactive. This makes the ellipses clickable buttons that expand to show all years.
