### PR TITLE
fix: use mergedAt for PR last activity date

### DIFF
--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -105,6 +105,7 @@ const GET_USER_CONTRIBUTIONS_QUERY = gql`
                 url
                 state
                 merged
+                mergedAt
               }
             }
           }
@@ -538,7 +539,10 @@ function aggregateActivityByRepository(
 
     repoContrib.contributions.nodes.forEach((contrib) => {
       if (contrib) {
-        const contributionDate = new Date(contrib.occurredAt);
+        const contributionDate = new Date(
+          (contrib.pullRequest.merged && contrib.pullRequest.mergedAt) ||
+            contrib.occurredAt,
+        );
         if (contributionDate > repo.lastActivity) {
           repo.lastActivity = contributionDate;
         }


### PR DESCRIPTION
The `contributionsCollection` API returns `occurredAt` as the PR creation date. For merged PRs, the merge date better reflects when the activity actually happened. This adds `mergedAt` to the GraphQL query and uses it for `lastActivity` when the PR is merged.
