### PR TITLE
feat: enable Cloudflare Workers tracing

### DIFF
--- a/workers/github/wrangler.toml
+++ b/workers/github/wrangler.toml
@@ -13,5 +13,8 @@ migrations_dir = "../../migrations"
 [observability]
 enabled = true
 
+[observability.traces]
+enabled = true
+
 [triggers]
 crons = ["0 * * * *"]

--- a/workers/strava/wrangler.toml
+++ b/workers/strava/wrangler.toml
@@ -21,5 +21,8 @@ STRAVA_USER_ID = "5723594"
 [observability]
 enabled = true
 
+[observability.traces]
+enabled = true
+
 [env.production.triggers]
 crons = ["0 */6 * * *"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,3 +21,6 @@ migrations_dir = "migrations"
 
 [observability]
 enabled = true
+
+[observability.traces]
+enabled = true


### PR DESCRIPTION
Enables automatic tracing for all three workers by adding `[observability.traces]` to each `wrangler.toml`. No code changes needed — Cloudflare instruments fetch calls, D1 queries, KV/R2 operations, and handler lifecycle automatically in the runtime.

Traces will appear in the Cloudflare dashboard under **Workers & Pages > Observability**. Tracing is in open beta (free until March 1, 2026).
