### PR TITLE
fix: update fast-xml-parser to 5.3.7 for security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8587,7 +8587,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.7.tgz",
+      "integrity": "sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==",
       "funding": [
         {
           "type": "github",
@@ -8596,7 +8598,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -9991,7 +9993,6 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
       "integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -14075,7 +14076,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Updates `fast-xml-parser` from 5.3.4 to 5.3.7, resolving two Dependabot security alerts:

- [#41](https://github.com/bendrucker/bendrucker.me/security/dependabot/41) (critical): entity encoding bypass via regex injection in DOCTYPE entity names
- [#35](https://github.com/bendrucker/bendrucker.me/security/dependabot/35) (high): DoS through entity expansion in DOCTYPE

Transitive dependency via `@astrojs/rss`. Lockfile-only change.
