### PR TITLE
Enable typescript-lsp and playground plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,8 @@
     ]
   },
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "playground@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
Enable `typescript-lsp` and `playground` plugins from the official marketplace alongside the existing `frontend-design` plugin.
