### PR TITLE
chore: remove unused sharp dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "reka-ui": "^2.9.2",
         "remark-collapse": "^0.1.2",
         "remark-toc": "^9.0.0",
-        "sharp": "^0.34.5",
         "shiki": "^4.0.2",
         "tailwindcss": "^4.2.0",
         "vue": "^3.5.29"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "reka-ui": "^2.9.2",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
-    "sharp": "^0.34.5",
     "shiki": "^4.0.2",
     "tailwindcss": "^4.2.0",
     "vue": "^3.5.29"


### PR DESCRIPTION
Removes `sharp` from dependencies. It's not imported anywhere. OG image generation uses `@cf-wasm/resvg` + `@cf-wasm/satori`, and the Cloudflare adapter handles build-time image optimization without `sharp`.
