### PR TITLE
fix: allow sandbox writes for wrangler

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,14 @@
       }
     ]
   },
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": [
+        "~/.config/.wrangler/logs",
+        "~/.config/.wrangler/registry"
+      ]
+    }
+  },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,


### PR DESCRIPTION
Adds `~/.config/.wrangler/logs` and `~/.config/.wrangler/registry` to the Claude Code sandbox filesystem write allowlist. The Cloudflare adapter starts miniflare during `astro check` and `astro build`, which writes to these paths. Without the allowlist entries, sandboxed builds fail with `EPERM`.
