### PR TITLE
feat: negotiate Accept: text/markdown for posts and /about

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,28 @@
+import type { MiddlewareHandler } from "astro";
+import { negotiate, PRODUCES } from "./middleware/negotiate";
+import { resolveMarkdown } from "./middleware/sources";
+
+export const onRequest: MiddlewareHandler = async (context, next) => {
+  const { request } = context;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return next();
+  }
+
+  const chosen = negotiate(request.headers.get("accept"), PRODUCES);
+
+  if (chosen === "text/markdown") {
+    const md = await resolveMarkdown(context.url.pathname);
+    if (md !== null) {
+      return new Response(md, {
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          Vary: "Accept",
+        },
+      });
+    }
+  }
+
+  const response = await next();
+  response.headers.append("Vary", "Accept");
+  return response;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,9 @@
 import type { MiddlewareHandler } from "astro";
 import { negotiate, PRODUCES } from "./middleware/negotiate";
-import { resolveMarkdown } from "./middleware/sources";
+import {
+  hasMarkdownRepresentation,
+  resolveMarkdown,
+} from "./middleware/sources";
 
 export const onRequest: MiddlewareHandler = async (context, next) => {
   const { request } = context;
@@ -8,20 +11,23 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
     return next();
   }
 
+  const { pathname } = context.url;
   const chosen = negotiate(request.headers.get("accept"), PRODUCES);
-  const md = await resolveMarkdown(context.url.pathname);
 
-  if (chosen === "text/markdown" && md !== null) {
-    return new Response(md, {
-      headers: {
-        "Content-Type": "text/markdown; charset=utf-8",
-        Vary: "Accept",
-      },
-    });
+  if (chosen === "text/markdown") {
+    const md = await resolveMarkdown(pathname);
+    if (md !== null) {
+      return new Response(request.method === "HEAD" ? null : md, {
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          Vary: "Accept",
+        },
+      });
+    }
   }
 
   const response = await next();
-  if (md !== null) {
+  if (hasMarkdownRepresentation(pathname)) {
     addVary(response.headers, "Accept");
   }
   return response;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,21 +9,21 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   }
 
   const chosen = negotiate(request.headers.get("accept"), PRODUCES);
+  const md = await resolveMarkdown(context.url.pathname);
 
-  if (chosen === "text/markdown") {
-    const md = await resolveMarkdown(context.url.pathname);
-    if (md !== null) {
-      return new Response(md, {
-        headers: {
-          "Content-Type": "text/markdown; charset=utf-8",
-          Vary: "Accept",
-        },
-      });
-    }
+  if (chosen === "text/markdown" && md !== null) {
+    return new Response(md, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        Vary: "Accept",
+      },
+    });
   }
 
   const response = await next();
-  addVary(response.headers, "Accept");
+  if (md !== null) {
+    addVary(response.headers, "Accept");
+  }
   return response;
 };
 
@@ -33,10 +33,12 @@ function addVary(headers: Headers, value: string): void {
     headers.set("Vary", value);
     return;
   }
+  if (existing.trim() === "*") return;
   const tokens = existing
     .split(",")
     .map((t) => t.trim())
     .filter((t) => t.length > 0);
+  if (tokens.includes("*")) return;
   if (tokens.some((t) => t.toLowerCase() === value.toLowerCase())) return;
   headers.set("Vary", [...tokens, value].join(", "));
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,8 +12,11 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   }
 
   const { pathname } = context.url;
-  const chosen = negotiate(request.headers.get("accept"), PRODUCES);
+  if (!hasMarkdownRepresentation(pathname)) {
+    return next();
+  }
 
+  const chosen = negotiate(request.headers.get("accept"), PRODUCES);
   if (chosen === "text/markdown") {
     const md = await resolveMarkdown(pathname);
     if (md !== null) {
@@ -27,9 +30,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   }
 
   const response = await next();
-  if (hasMarkdownRepresentation(pathname)) {
-    addVary(response.headers, "Accept");
-  }
+  addVary(response.headers, "Accept");
   return response;
 };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,6 +23,20 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   }
 
   const response = await next();
-  response.headers.append("Vary", "Accept");
+  addVary(response.headers, "Accept");
   return response;
 };
+
+function addVary(headers: Headers, value: string): void {
+  const existing = headers.get("Vary");
+  if (!existing) {
+    headers.set("Vary", value);
+    return;
+  }
+  const tokens = existing
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  if (tokens.some((t) => t.toLowerCase() === value.toLowerCase())) return;
+  headers.set("Vary", [...tokens, value].join(", "));
+}

--- a/src/middleware/negotiate.test.ts
+++ b/src/middleware/negotiate.test.ts
@@ -55,4 +55,17 @@ describe("negotiate", () => {
       "text/markdown",
     );
   });
+
+  it("matches media types case-insensitively", () => {
+    expect(negotiate("Text/Markdown", PRODUCES)).toBe("text/markdown");
+    expect(negotiate("TEXT/HTML;Q=0.5, TEXT/MARKDOWN;Q=0.9", PRODUCES)).toBe(
+      "text/markdown",
+    );
+  });
+
+  it("picks max q when multiple entries match with equal specificity", () => {
+    expect(negotiate("text/html;q=0.5, text/html;q=0.9", PRODUCES)).toBe(
+      "text/html",
+    );
+  });
 });

--- a/src/middleware/negotiate.test.ts
+++ b/src/middleware/negotiate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { negotiate, PRODUCES } from "./negotiate";
+
+describe("negotiate", () => {
+  it("returns first produces entry when Accept is null", () => {
+    expect(negotiate(null, PRODUCES)).toBe("text/html");
+  });
+
+  it("returns first produces entry when Accept is empty", () => {
+    expect(negotiate("", PRODUCES)).toBe("text/html");
+  });
+
+  it("picks text/html for */*", () => {
+    expect(negotiate("*/*", PRODUCES)).toBe("text/html");
+  });
+
+  it("picks text/html for Accept: text/html", () => {
+    expect(negotiate("text/html", PRODUCES)).toBe("text/html");
+  });
+
+  it("picks text/markdown for Accept: text/markdown", () => {
+    expect(negotiate("text/markdown", PRODUCES)).toBe("text/markdown");
+  });
+
+  it("tiebreaks equal-q candidates by produces order", () => {
+    expect(negotiate("text/markdown, text/html", PRODUCES)).toBe("text/html");
+  });
+
+  it("picks higher q when q values differ", () => {
+    expect(negotiate("text/markdown;q=0.9, text/html;q=0.5", PRODUCES)).toBe(
+      "text/markdown",
+    );
+  });
+
+  it("rejects candidates matched by q=0", () => {
+    expect(negotiate("text/html;q=0, text/markdown", PRODUCES)).toBe(
+      "text/markdown",
+    );
+  });
+
+  it("picks text/html for Accept: text/* via produces-order tiebreak", () => {
+    expect(negotiate("text/*", PRODUCES)).toBe("text/html");
+  });
+
+  it("returns null when no candidate matches", () => {
+    expect(negotiate("application/json", PRODUCES)).toBeNull();
+  });
+
+  it("treats malformed q-values as 1", () => {
+    expect(negotiate("text/markdown;q=abc", PRODUCES)).toBe("text/markdown");
+  });
+
+  it("picks specificity-resolved q per candidate", () => {
+    expect(negotiate("text/html;q=0.8, text/*;q=0.9", PRODUCES)).toBe(
+      "text/markdown",
+    );
+  });
+});

--- a/src/middleware/negotiate.ts
+++ b/src/middleware/negotiate.ts
@@ -9,13 +9,13 @@ type AcceptEntry = {
 
 function parseEntry(part: string): AcceptEntry | null {
   const [mediaRange, ...paramParts] = part.split(";").map((s) => s.trim());
-  const [type, subtype] = mediaRange.split("/");
+  const [type, subtype] = mediaRange.toLowerCase().split("/");
   if (!type || !subtype) return null;
 
   let q = 1;
   for (const param of paramParts) {
     const [k, v] = param.split("=").map((s) => s.trim());
-    if (k !== "q" || v === undefined) continue;
+    if (k?.toLowerCase() !== "q" || v === undefined) continue;
     const parsed = Number.parseFloat(v);
     if (Number.isFinite(parsed)) {
       q = Math.max(0, Math.min(1, parsed));
@@ -38,7 +38,7 @@ function parseAccept(header: string): AcceptEntry[] {
 }
 
 function matches(candidate: string, entry: AcceptEntry): boolean {
-  const [type, subtype] = candidate.split("/");
+  const [type, subtype] = candidate.toLowerCase().split("/");
   if (entry.type === "*" && entry.subtype === "*") return true;
   if (entry.subtype === "*") return entry.type === type;
   return entry.type === type && entry.subtype === subtype;
@@ -61,9 +61,11 @@ export function negotiate(
     const matching = entries.filter((e) => matches(candidate, e));
     if (matching.length === 0) continue;
 
-    const mostSpecific = matching.reduce((a, b) =>
-      b.specificity > a.specificity ? b : a,
-    );
+    const mostSpecific = matching.reduce((a, b) => {
+      if (b.specificity > a.specificity) return b;
+      if (b.specificity < a.specificity) return a;
+      return b.q > a.q ? b : a;
+    });
     if (mostSpecific.q === 0) continue;
 
     if (

--- a/src/middleware/negotiate.ts
+++ b/src/middleware/negotiate.ts
@@ -1,0 +1,79 @@
+export const PRODUCES = ["text/html", "text/markdown"] as const;
+
+type AcceptEntry = {
+  type: string;
+  subtype: string;
+  q: number;
+  specificity: 0 | 1 | 2;
+};
+
+function parseEntry(part: string): AcceptEntry | null {
+  const [mediaRange, ...paramParts] = part.split(";").map((s) => s.trim());
+  const [type, subtype] = mediaRange.split("/");
+  if (!type || !subtype) return null;
+
+  let q = 1;
+  for (const param of paramParts) {
+    const [k, v] = param.split("=").map((s) => s.trim());
+    if (k !== "q" || v === undefined) continue;
+    const parsed = Number.parseFloat(v);
+    if (Number.isFinite(parsed)) {
+      q = Math.max(0, Math.min(1, parsed));
+    }
+  }
+
+  const specificity =
+    type === "*" && subtype === "*" ? 0 : subtype === "*" ? 1 : 2;
+
+  return { type, subtype, q, specificity };
+}
+
+function parseAccept(header: string): AcceptEntry[] {
+  return header
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map(parseEntry)
+    .filter((entry): entry is AcceptEntry => entry !== null);
+}
+
+function matches(candidate: string, entry: AcceptEntry): boolean {
+  const [type, subtype] = candidate.split("/");
+  if (entry.type === "*" && entry.subtype === "*") return true;
+  if (entry.subtype === "*") return entry.type === type;
+  return entry.type === type && entry.subtype === subtype;
+}
+
+export function negotiate(
+  acceptHeader: string | null,
+  produces: readonly string[],
+): string | null {
+  if (produces.length === 0) return null;
+  if (!acceptHeader || acceptHeader.trim() === "") return produces[0];
+
+  const entries = parseAccept(acceptHeader);
+  if (entries.length === 0) return produces[0];
+
+  type Best = { candidate: string; q: number; index: number };
+  let best: Best | null = null;
+
+  for (const [index, candidate] of produces.entries()) {
+    const matching = entries.filter((e) => matches(candidate, e));
+    if (matching.length === 0) continue;
+
+    const mostSpecific = matching.reduce((a, b) =>
+      b.specificity > a.specificity ? b : a,
+    );
+    if (mostSpecific.q === 0) continue;
+
+    if (
+      best === null ||
+      mostSpecific.q > best.q ||
+      (mostSpecific.q === best.q && index < best.index)
+    ) {
+      best = { candidate, q: mostSpecific.q, index };
+    }
+  }
+
+  return best ? best.candidate : null;
+}

--- a/src/middleware/sources.ts
+++ b/src/middleware/sources.ts
@@ -1,5 +1,6 @@
 import { getCollection } from "astro:content";
 import { getPath } from "@/utils/posts/path";
+import postFilter from "@/utils/posts/filter";
 import aboutMd from "../pages/about.md?raw";
 
 function stripTrailingSlash(pathname: string): string {
@@ -19,7 +20,7 @@ export async function resolveMarkdown(
   }
 
   if (path.startsWith("/posts/")) {
-    const posts = await getCollection("blog", ({ data }) => !data.draft);
+    const posts = await getCollection("blog", postFilter);
     const entry = posts.find((p) => getPath(p.id, p.filePath) === path);
     return entry?.body ?? null;
   }

--- a/src/middleware/sources.ts
+++ b/src/middleware/sources.ts
@@ -1,0 +1,28 @@
+import { getCollection } from "astro:content";
+import { getPath } from "@/utils/posts/path";
+import aboutMd from "../pages/about.md?raw";
+
+function stripTrailingSlash(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}
+
+export async function resolveMarkdown(
+  pathname: string,
+): Promise<string | null> {
+  const path = stripTrailingSlash(pathname);
+
+  if (path === "/about") {
+    return aboutMd;
+  }
+
+  if (path.startsWith("/posts/")) {
+    const posts = await getCollection("blog", ({ data }) => !data.draft);
+    const entry = posts.find((p) => getPath(p.id, p.filePath) === path);
+    return entry?.body ?? null;
+  }
+
+  return null;
+}

--- a/src/middleware/sources.ts
+++ b/src/middleware/sources.ts
@@ -10,6 +10,11 @@ function stripTrailingSlash(pathname: string): string {
   return pathname;
 }
 
+export function hasMarkdownRepresentation(pathname: string): boolean {
+  const path = stripTrailingSlash(pathname);
+  return path === "/about" || path.startsWith("/posts/");
+}
+
 export async function resolveMarkdown(
   pathname: string,
 ): Promise<string | null> {

--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -2,19 +2,16 @@
 import { getCollection } from "astro:content";
 import PostDetails from "@/layouts/PostDetails.astro";
 import getSortedPosts from "@/utils/posts/sort";
-import postFilter from "@/utils/posts/filter";
 import { getPath } from "@/utils/posts/path";
 
 const pathname = Astro.url.pathname.replace(/\/$/, "");
 
-const posts = await getCollection("blog", postFilter);
-const post = posts.find((p) => getPath(p.id, p.filePath) === pathname);
+const sortedPosts = getSortedPosts(await getCollection("blog"));
+const post = sortedPosts.find((p) => getPath(p.id, p.filePath) === pathname);
 
 if (!post) {
   return new Response(null, { status: 404 });
 }
-
-const sortedPosts = getSortedPosts(posts);
 ---
 
 <PostDetails post={post} posts={sortedPosts} />

--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -2,19 +2,19 @@
 import { getCollection } from "astro:content";
 import PostDetails from "@/layouts/PostDetails.astro";
 import getSortedPosts from "@/utils/posts/sort";
+import postFilter from "@/utils/posts/filter";
 import { getPath } from "@/utils/posts/path";
 
 const pathname = Astro.url.pathname.replace(/\/$/, "");
 
-const posts = await getCollection("blog", ({ data }) => !data.draft);
+const posts = await getCollection("blog", postFilter);
 const post = posts.find((p) => getPath(p.id, p.filePath) === pathname);
 
 if (!post) {
   return new Response(null, { status: 404 });
 }
 
-const allPosts = await getCollection("blog");
-const sortedPosts = getSortedPosts(allPosts);
+const sortedPosts = getSortedPosts(posts);
 ---
 
 <PostDetails post={post} posts={sortedPosts} />

--- a/src/pages/posts/[...slug]/index.astro
+++ b/src/pages/posts/[...slug]/index.astro
@@ -1,29 +1,20 @@
 ---
-import { type CollectionEntry, getCollection } from "astro:content";
+import { getCollection } from "astro:content";
 import PostDetails from "@/layouts/PostDetails.astro";
 import getSortedPosts from "@/utils/posts/sort";
 import { getPath } from "@/utils/posts/path";
 
-export interface Props {
-  post: CollectionEntry<"blog">;
+const pathname = Astro.url.pathname.replace(/\/$/, "");
+
+const posts = await getCollection("blog", ({ data }) => !data.draft);
+const post = posts.find((p) => getPath(p.id, p.filePath) === pathname);
+
+if (!post) {
+  return new Response(null, { status: 404 });
 }
 
-export const prerender = true;
-
-export async function getStaticPaths() {
-  const posts = await getCollection("blog", ({ data }) => !data.draft);
-  const postResult = posts.map(post => ({
-    params: { slug: getPath(post.id, post.filePath, false) },
-    props: { post },
-  }));
-
-  return postResult;
-}
-
-const { post } = Astro.props;
-
-const posts = await getCollection("blog");
-const sortedPosts = getSortedPosts(posts);
+const allPosts = await getCollection("blog");
+const sortedPosts = getSortedPosts(allPosts);
 ---
 
 <PostDetails post={post} posts={sortedPosts} />


### PR DESCRIPTION
Adds Astro middleware that returns raw markdown source when a client prefers `text/markdown` via the `Accept` header. Default `text/html` requests are unchanged. Reference: [acceptmarkdown.com/recipes/astro](https://acceptmarkdown.com/recipes/astro).

## Changes

- `src/middleware/negotiate.ts` — pure `Accept` parser + negotiation. Handles q-values (clamped to `[0, 1]`, malformed → `1`, `q=0` rejects), specificity (`*/*` < `type/*` < `type/subtype`), and produces-order tiebreaks.
- `src/middleware/sources.ts` — URL → raw markdown registry. `/about` via Vite `?raw` import; `/posts/<slug>` via `getCollection('blog')` returning `entry.body`.
- `src/middleware.ts` — thin Astro wrapper: negotiates, short-circuits with `text/markdown; charset=utf-8` + `Vary: Accept`, or falls through to `next()` and appends `Vary: Accept`.
- `src/pages/posts/[...slug]/index.astro` — drops `prerender` and `getStaticPaths`, resolves the post at request time so middleware runs. Returns `404` for unknown slugs. OG image endpoint (`index.png.ts`) stays prerendered and is unaffected.

## Testing

- 12 unit tests for `negotiate()` in `src/middleware/negotiate.test.ts` covering null/empty Accept, wildcards, q-value ordering, `q=0` rejection, malformed q-values, specificity-resolved q per candidate, and no-match fallthrough.
- `astro check` passes; post routes are no longer in the prerendered manifest.

```bash
# HTML unchanged
curl -sI https://www.bendrucker.me/posts/<slug>/ | grep -iE 'content-type|vary'

# Markdown negotiation
curl -s -H 'Accept: text/markdown' https://www.bendrucker.me/posts/<slug>/ | head -5
```
