### PR TITLE
refactor: route activity-code initial load through queryRepos

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/ben/src/bendrucker/bendrucker.me/node_modules

--- a/src/pages/activity/code.astro
+++ b/src/pages/activity/code.astro
@@ -1,12 +1,11 @@
 ---
-import { sql } from "kysely";
 import Layout from "../../layouts/Layout.astro";
 import Main from "../../layouts/Main.astro";
 import { SITE } from "../../config";
 import ActivityTimeline from "../../components/activity/ActivityTimeline.vue";
 import type { Repo } from "../../components/activity/composables/useActivityApi";
 import { getDb } from "@/db";
-import { repoQuery, mapRepoRow, queryRepos } from "./code/_query";
+import { queryRepos } from "./code/_query";
 import { formatReposMarkdown } from "./code/_markdown";
 import { logger } from "@workspace/logger";
 
@@ -26,27 +25,11 @@ let initialHasMore = false;
 let initialCursor: string | null = null;
 
 try {
-  const countResult = await db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .select(sql<number>`count(distinct ${sql.ref("repos.id")})`.as("total"))
-    .executeTakeFirstOrThrow();
-  initialTotal = countResult.total;
-
-  const results = await repoQuery(db)
-    .orderBy(sql`last_activity`, "desc")
-    .limit(21)
-    .execute();
-
-  initialHasMore = results.length > 20;
-  const pageResults = initialHasMore ? results.slice(0, 20) : results;
-
-  if (pageResults.length > 0) {
-    const last = pageResults[pageResults.length - 1];
-    initialCursor = `${last.lastActivity}|${last.id}`;
-  }
-
-  initialRepos = pageResults.map(mapRepoRow);
+  const result = await queryRepos(db, {});
+  initialRepos = result.repos;
+  initialTotal = result.total;
+  initialHasMore = result.hasMore;
+  initialCursor = result.nextCursor;
 } catch (error) {
   logger.error({ error }, "Failed to load activity data");
 }


### PR DESCRIPTION
Routes the activity-code HTML initial load through `queryRepos` instead of a hand-rolled copy of its pagination. The markdown path and every server action already call `queryRepos`; the initial-load path was the last one reimplementing the inline count query, `repoQuery(...).limit(21)`, the `slice(0, 20)`/`hasMore` split, and the `${lastActivity}|${id}` cursor by hand.

`queryRepos(db, {})` returns `{ repos, nextCursor, hasMore, total }` for the default `recent` sort with no cursor, which maps directly onto the four `initial*` values the page builds.

## Changes

- Replaced the inline count query and `repoQuery` pagination block with a single `queryRepos(db, {})` call inside the existing try/catch.
- Removed the now-unused `sql`, `repoQuery`, and `mapRepoRow` imports.
- Kept the markdown short-circuit path unchanged.

Behavior is unchanged. The one observable difference is intentional: the old code set `initialCursor` whenever the page had results, even on the last page; `queryRepos` returns `nextCursor: null` when `hasMore` is false, since a cursor with no next page is meaningless.

## Testing

`_query.test.ts` already covers `queryRepos`, including the default `recent` sort, cursor generation, and `hasMore`/`total` shape. The page now exercises that tested seam rather than a parallel copy, so the cursor logic lives in one place.
