### PR TITLE
refactor: write GitHub cron through the typed upsert seam

### DIFF
--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -13,7 +13,7 @@ import {
 } from "@workspace/github";
 import { logger } from "@workspace/logger";
 import { connectD1, formatSql, executeRemote } from "./d1";
-import { upsertRepo, upsertActivity } from "./upsert";
+import { upsertRepo, upsertActivity } from "../src/activity/upsert";
 
 async function rateLimitBackoff(rateLimit: RateLimit): Promise<void> {
   const { remaining, cost, resetAt } = rateLimit;

--- a/scripts/fetch-github-activity.ts
+++ b/scripts/fetch-github-activity.ts
@@ -7,7 +7,7 @@ import type { RepoActivity } from "@workspace/github";
 import { fetchGitHubActivityWithConfig } from "../src/services/github";
 import { logger } from "@workspace/logger";
 import { connectD1, formatSql, executeRemote } from "./d1";
-import { upsertRepo, upsertActivity } from "./upsert";
+import { upsertRepo, upsertActivity } from "../src/activity/upsert";
 
 async function main() {
   const startTime = Date.now();

--- a/scripts/generate-language-extensions.ts
+++ b/scripts/generate-language-extensions.ts
@@ -5,7 +5,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { logger } from "@workspace/logger";
 import { connectD1, formatSql, executeRemote } from "./d1";
-import { upsertLanguageExtension } from "./upsert";
+import { upsertLanguageExtension } from "../src/activity/upsert";
 
 const require = createRequire(import.meta.url);
 const pkgDir = join(require.resolve("linguist-languages"), "..");

--- a/src/activity/upsert.test.ts
+++ b/src/activity/upsert.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Kysely } from "kysely";
+import type { Database } from "@/db";
+import { createTestDb } from "@/test/db";
+import type { RepoActivity } from "@workspace/github";
+import { upsertRepo, upsertActivity } from "./upsert";
+
+function makeRepo(overrides: Partial<RepoActivity> = {}): RepoActivity {
+  return {
+    owner: "bendrucker",
+    name: "cool-lib",
+    description: "A cool library",
+    url: "https://github.com/bendrucker/cool-lib",
+    lastActivity: new Date("2025-06-01T00:00:00.000Z"),
+    createdAt: new Date("2020-01-01T00:00:00.000Z"),
+    primaryLanguage: { name: "TypeScript", color: "#3178c6" },
+    stargazerCount: 100,
+    activitySummary: {
+      prCount: 5,
+      reviewCount: 2,
+      issueCount: 1,
+      mergeCount: 3,
+      hasMergedPRs: true,
+    },
+    ...overrides,
+  };
+}
+
+describe("upsert builders", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("inserts a repo and its activity", async () => {
+    const repo = makeRepo();
+    await upsertRepo(db, repo).execute();
+    await upsertActivity(db, repo).execute();
+
+    const stored = await db
+      .selectFrom("repos")
+      .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
+      .selectAll()
+      .executeTakeFirstOrThrow();
+
+    expect(stored.owner).toBe("bendrucker");
+    expect(stored.name).toBe("cool-lib");
+    expect(stored.primaryLanguageName).toBe("TypeScript");
+    expect(stored.primaryLanguageColor).toBe("#3178c6");
+    expect(stored.stargazerCount).toBe(100);
+    expect(stored.createdAt).toBe("2020-01-01T00:00:00.000Z");
+    expect(stored.prCount).toBe(5);
+    expect(stored.reviewCount).toBe(2);
+    expect(stored.issueCount).toBe(1);
+    expect(stored.mergeCount).toBe(3);
+    expect(stored.hasMergedPrs).toBe(1);
+    expect(stored.lastActivity).toBe(
+      Math.floor(repo.lastActivity.getTime() / 1000),
+    );
+    expect(stored.year).toBe(2025);
+  });
+
+  it("updates existing rows on conflict instead of duplicating", async () => {
+    const initial = makeRepo();
+    await upsertRepo(db, initial).execute();
+    await upsertActivity(db, initial).execute();
+
+    const updated = makeRepo({
+      description: "An even cooler library",
+      stargazerCount: 200,
+      lastActivity: new Date("2025-09-01T00:00:00.000Z"),
+      activitySummary: {
+        prCount: 12,
+        reviewCount: 4,
+        issueCount: 2,
+        mergeCount: 6,
+        hasMergedPRs: true,
+      },
+    });
+    await upsertRepo(db, updated).execute();
+    await upsertActivity(db, updated).execute();
+
+    const repos = await db.selectFrom("repos").selectAll().execute();
+    expect(repos).toHaveLength(1);
+    expect(repos[0].description).toBe("An even cooler library");
+    expect(repos[0].stargazerCount).toBe(200);
+
+    const activity = await db.selectFrom("repoActivity").selectAll().execute();
+    expect(activity).toHaveLength(1);
+    expect(activity[0].prCount).toBe(12);
+    expect(activity[0].lastActivity).toBe(
+      Math.floor(updated.lastActivity.getTime() / 1000),
+    );
+  });
+
+  it("handles a null primary language", async () => {
+    const repo = makeRepo({ primaryLanguage: null });
+    await upsertRepo(db, repo).execute();
+
+    const stored = await db
+      .selectFrom("repos")
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(stored.primaryLanguageName).toBeNull();
+    expect(stored.primaryLanguageColor).toBeNull();
+  });
+});

--- a/src/activity/upsert.ts
+++ b/src/activity/upsert.ts
@@ -1,5 +1,5 @@
 import { sql, type Kysely } from "kysely";
-import type { Database } from "../src/db";
+import type { Database } from "../db";
 import type { RepoActivity } from "@workspace/github";
 
 export function upsertRepo(db: Kysely<Database>, repo: RepoActivity) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,5 @@
 import { CamelCasePlugin, Kysely, type Generated } from "kysely";
-import { D1Dialect } from "@/d1-dialect";
+import { D1Dialect } from "./d1-dialect";
 
 export interface ReposTable {
   id: Generated<number>;

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -4,7 +4,10 @@ import { logger } from "@workspace/logger";
 
 export * from "@workspace/github";
 
-export function fetchGitHubActivityWithConfig(token: string) {
+export function fetchGitHubActivityWithConfig(
+  token: string,
+  window?: { from?: Date; to?: Date },
+) {
   logger.debug(
     {
       username: SITE.githubUsername,
@@ -16,5 +19,7 @@ export function fetchGitHubActivityWithConfig(token: string) {
   return fetchGitHubActivity(token, {
     username: SITE.githubUsername,
     title: SITE.title,
+    from: window?.from,
+    to: window?.to,
   });
 }

--- a/workers/github/main.ts
+++ b/workers/github/main.ts
@@ -1,78 +1,40 @@
-import { fetchGitHubActivity, type RepoActivity } from "@workspace/github";
+import type { RepoActivity } from "@workspace/github";
 import { logger } from "@workspace/logger";
+import type { CompiledQuery } from "kysely";
+import { createDb } from "../../src/db";
+import { upsertRepo, upsertActivity } from "../../src/activity/upsert";
+import { fetchGitHubActivityWithConfig } from "../../src/services/github";
 
 interface Env {
   GITHUB_TOKEN: string;
   ACTIVITY_DB: D1Database;
 }
 
+const BATCH_SIZE = 500;
+
+function prepare(d1: D1Database, query: CompiledQuery): D1PreparedStatement {
+  return d1.prepare(query.sql).bind(...query.parameters);
+}
+
 async function upsertActivityToD1(
-  db: D1Database,
+  d1: D1Database,
   repos: RepoActivity[],
 ): Promise<void> {
+  const db = createDb(d1);
+
   const statements: D1PreparedStatement[] = [];
-
   for (const repo of repos) {
-    statements.push(
-      db
-        .prepare(
-          `INSERT INTO repos (owner, name, description, url, primary_language_name, primary_language_color, stargazer_count, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(owner, name) DO UPDATE SET
-             description=excluded.description,
-             url=excluded.url,
-             primary_language_name=excluded.primary_language_name,
-             primary_language_color=excluded.primary_language_color,
-             stargazer_count=excluded.stargazer_count,
-             updated_at=datetime('now')`,
-        )
-        .bind(
-          repo.owner,
-          repo.name,
-          repo.description,
-          repo.url,
-          repo.primaryLanguage?.name ?? null,
-          repo.primaryLanguage?.color ?? null,
-          repo.stargazerCount,
-          repo.createdAt ? repo.createdAt.toISOString() : null,
-        ),
-    );
-
-    const lastActivity = Math.floor(repo.lastActivity.getTime() / 1000);
-
-    statements.push(
-      db
-        .prepare(
-          `INSERT INTO repo_activity (repo_id, pr_count, review_count, issue_count, merge_count, has_merged_prs, last_activity)
-           VALUES ((SELECT id FROM repos WHERE owner=? AND name=?), ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(repo_id, year) DO UPDATE SET
-             pr_count=excluded.pr_count,
-             review_count=excluded.review_count,
-             issue_count=excluded.issue_count,
-             merge_count=excluded.merge_count,
-             has_merged_prs=excluded.has_merged_prs,
-             last_activity=excluded.last_activity`,
-        )
-        .bind(
-          repo.owner,
-          repo.name,
-          repo.activitySummary.prCount,
-          repo.activitySummary.reviewCount,
-          repo.activitySummary.issueCount,
-          repo.activitySummary.mergeCount,
-          repo.activitySummary.hasMergedPRs ? 1 : 0,
-          lastActivity,
-        ),
-    );
+    statements.push(prepare(d1, upsertRepo(db, repo).compile()));
+    statements.push(prepare(d1, upsertActivity(db, repo).compile()));
   }
 
-  const BATCH_SIZE = 500;
   let totalResults = 0;
   for (let i = 0; i < statements.length; i += BATCH_SIZE) {
     const chunk = statements.slice(i, i + BATCH_SIZE);
-    const results = await db.batch(chunk);
+    const results = await d1.batch(chunk);
     totalResults += results.length;
   }
+
   logger.info(
     {
       statements: statements.length,
@@ -93,12 +55,10 @@ async function updateGitHubActivity(env: Env): Promise<RepoActivity[]> {
 
   const now = new Date();
   const yearStart = new Date(now.getFullYear(), 0, 1);
-  const { repos: activityData } = await fetchGitHubActivity(env.GITHUB_TOKEN, {
-    username: "bendrucker",
-    title: "Ben Drucker",
-    from: yearStart,
-    to: now,
-  });
+  const { repos: activityData } = await fetchGitHubActivityWithConfig(
+    env.GITHUB_TOKEN,
+    { from: yearStart, to: now },
+  );
 
   await upsertActivityToD1(env.ACTIVITY_DB, activityData);
 

--- a/workers/github/tsconfig.json
+++ b/workers/github/tsconfig.json
@@ -3,5 +3,13 @@
   "references": [
     { "path": "../../packages/github" },
     { "path": "../../packages/logger" }
+  ],
+  "include": [
+    "*.ts",
+    "../../src/db.ts",
+    "../../src/d1-dialect.ts",
+    "../../src/config.ts",
+    "../../src/activity/**/*.ts",
+    "../../src/services/github.ts"
   ]
 }

--- a/workers/github/tsconfig.json
+++ b/workers/github/tsconfig.json
@@ -11,5 +11,6 @@
     "../../src/config.ts",
     "../../src/activity/**/*.ts",
     "../../src/services/github.ts"
-  ]
+  ],
+  "exclude": ["../../src/**/*.test.ts"]
 }


### PR DESCRIPTION
The hourly GitHub cron worker reimplemented the `RepoActivity -> D1` write as raw SQL strings, duplicating the typed Kysely builders that `scripts/fetch-github-activity.ts` and `scripts/backfill-github-activity.ts` already share. The worker also hardcoded `username`/`title` that the scripts read from `SITE`. This collapses both write paths into one typed seam.

## Changes

- Moved the upsert builders from `scripts/upsert.ts` to `src/activity/upsert.ts` so the worker and scripts import one typed module. Updated the three script imports (`fetch`, `backfill`, `generate-language-extensions`).
- Rewrote the worker to build a `Kysely<Database>` via `createDb(env.ACTIVITY_DB)`, compile each upsert, and feed the prepared statements into `db.batch`. Batching is preserved: same 500-statement chunks, same repo-before-activity ordering the `repoId` subquery depends on.
- Switched the worker to `fetchGitHubActivityWithConfig`, which derives `username`/`title` from `SITE`. I extended that function with an optional `from`/`to` window so the worker keeps its year-start fetch range. The two hardcoded literals are gone.
- Changed `src/db.ts` to import `./d1-dialect` relatively instead of via the `@/` alias, since the worker bundle resolves relative paths but not the Astro `@/` path.

A schema rename now breaks the build instead of failing silently in production.

## Config Import Constraint

`src/config.ts` (`SITE`) is a plain object literal with no Astro dependencies, so the worker bundles it cleanly. I verified the worker entry bundles with no unresolved imports. `workers/github/tsconfig.json` gains a scoped `include` listing only the `src/` files in the worker's import graph, avoiding pulling Astro-only sources into the worker typecheck.

## Testing

- Added `src/activity/upsert.test.ts`: round-trip insert, conflict-update (no duplicate rows), generated `year` column, and null `primaryLanguage`, against the in-memory SQLite test DB.
- Verified the compiled SQL/params match the original raw SQL exactly: `snake_case` columns, `ON CONFLICT(owner, name)` / `ON CONFLICT(repo_id, year)`, `year` omitted on insert, `hasMergedPRs` boolean to int, and the epoch-seconds `lastActivity` conversion.
- Lint, test suite, and the full build (`wrangler types` + `astro check` + `astro build`) all pass.
