### PR TITLE
refactor: modernize array idioms and module resolution

### DIFF
--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -677,5 +677,5 @@ function aggregateActivityByRepository(
         repo.activitySummary.mergeCount > 0
       );
     })
-    .sort((a, b) => b.lastActivity.getTime() - a.lastActivity.getTime());
+    .toSorted((a, b) => b.lastActivity.getTime() - a.lastActivity.getTime());
 }

--- a/src/blog/posts.ts
+++ b/src/blog/posts.ts
@@ -11,7 +11,7 @@ export const postFilter = ({ data }: CollectionEntry<"blog">) => {
 export const getSortedPosts = (posts: CollectionEntry<"blog">[]) =>
   posts
     .filter(postFilter)
-    .sort(
+    .toSorted(
       (a, b) =>
         Math.floor(
           new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000,

--- a/src/blog/tags.ts
+++ b/src/blog/tags.ts
@@ -21,4 +21,4 @@ export const getUniqueTags = (posts: CollectionEntry<"blog">[]) =>
       (value, index, self) =>
         self.findIndex((tag) => tag.tag === value.tag) === index,
     )
-    .sort((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));
+    .toSorted((tagA, tagB) => tagA.tag.localeCompare(tagB.tag));

--- a/src/components/activity/TimelineRail.vue
+++ b/src/components/activity/TimelineRail.vue
@@ -38,8 +38,8 @@ const visibleYears = computed(() => {
 
 const hasOlderYears = computed(() => {
   if (expanded.value || props.years.length <= MAX_VISIBLE) return false;
-  const last = windowedYears.value[windowedYears.value.length - 1];
-  const allLast = props.years[props.years.length - 1];
+  const last = windowedYears.value.at(-1);
+  const allLast = props.years.at(-1);
   return last && allLast && last.year > allLast.year;
 });
 

--- a/src/components/activity/YearActivity.vue
+++ b/src/components/activity/YearActivity.vue
@@ -55,13 +55,13 @@ function actionInput() {
 }
 
 const prevYear = computed(() => {
-  const sorted = props.years.map((y) => y.year).sort((a, b) => b - a);
+  const sorted = props.years.map((y) => y.year).toSorted((a, b) => b - a);
   const idx = sorted.indexOf(props.year);
   return idx >= 0 && idx < sorted.length - 1 ? sorted[idx + 1] : null;
 });
 
 const nextYear = computed(() => {
-  const sorted = props.years.map((y) => y.year).sort((a, b) => b - a);
+  const sorted = props.years.map((y) => y.year).toSorted((a, b) => b - a);
   const idx = sorted.indexOf(props.year);
   return idx > 0 ? sorted[idx - 1] : null;
 });
@@ -85,8 +85,8 @@ const footerYears = computed(() => {
 
 const hasOlderFooterYears = computed(() => {
   if (props.years.length <= MAX_FOOTER_YEARS) return false;
-  const last = footerYears.value[footerYears.value.length - 1];
-  const allLast = props.years[props.years.length - 1];
+  const last = footerYears.value.at(-1);
+  const allLast = props.years.at(-1);
   return last && allLast && last.year > allLast.year;
 });
 

--- a/src/pages/activity/code/_query.ts
+++ b/src/pages/activity/code/_query.ts
@@ -127,7 +127,7 @@ export function mapRepoRow(row: {
       ? row.years
           .split(",")
           .map(Number)
-          .sort((a: number, b: number) => b - a)
+          .toSorted((a: number, b: number) => b - a)
       : [],
   };
 }

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -15,15 +15,6 @@ if (!SITE.showArchives) {
 
 const posts = await getCollection("blog", postFilter);
 
-const groupBy = <T,>(items: T[], keyOf: (item: T) => string | number) => {
-  const groups: Record<string | number, T[]> = {};
-  for (const item of items) {
-    const key = keyOf(item);
-    (groups[key] ??= []).push(item);
-  }
-  return groups;
-};
-
 const months = [
   "January",
   "February",
@@ -44,18 +35,20 @@ const months = [
   <Main pageTitle="Archives" pageDesc="All the articles I've archived.">
     {
       Object.entries(
-        groupBy(posts, post => post.data.pubDatetime.getFullYear())
+        Object.groupBy(posts, post => post.data.pubDatetime.getFullYear())
       )
-        .sort(([yearA], [yearB]) => Number(yearB) - Number(yearA))
-        .map(([year, yearGroup]) => (
+        .toSorted(([yearA], [yearB]) => Number(yearB) - Number(yearA))
+        .map(([year, yearGroup = []]) => (
           <div>
             <span class="text-2xl font-bold">{year}</span>
             <sup class="text-sm">{yearGroup.length}</sup>
             {Object.entries(
-              groupBy(yearGroup, post => post.data.pubDatetime.getMonth() + 1)
+              Object.groupBy(yearGroup, post =>
+                post.data.pubDatetime.getMonth() + 1
+              )
             )
-              .sort(([monthA], [monthB]) => Number(monthB) - Number(monthA))
-              .map(([month, monthGroup]) => (
+              .toSorted(([monthA], [monthB]) => Number(monthB) - Number(monthA))
+              .map(([month, monthGroup = []]) => (
                 <div class="flex flex-col sm:flex-row">
                   <div class="mt-6 min-w-36 text-lg sm:my-6">
                     <span class="font-bold">{months[Number(month) - 1]}</span>
@@ -63,7 +56,7 @@ const months = [
                   </div>
                   <ul>
                     {monthGroup
-                      .sort(
+                      .toSorted(
                         (a, b) =>
                           Math.floor(
                             new Date(b.data.pubDatetime).getTime() / 1000

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ES2022",
     "moduleResolution": "node",
     "ignoreDeprecations": "6.0",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2023",
-    "module": "ES2022",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "ignoreDeprecations": "6.0",
     "incremental": true,
     "sourceMap": true,


### PR DESCRIPTION
Modernizes code that predates ECMAScript stdlib methods now available everywhere this project runs. The repo has no `engines` floor and deploys to a current Workers runtime, so the budget here is pure idiom adoption rather than a version bump. The dependency axis was empty (Astro 6, Tailwind 4, Vue 3.5, TS 6, etc. are all current), so this is language-feature only.

## Array Idioms

- `Object.groupBy` replaces the hand-rolled `groupBy` helper in `archives`. Its return type is `Partial<Record<…>>`, so the destructuring uses `= []` defaults (`[year, yearGroup = []]`) to stay type-clean. The defaults never fire, since `Object.entries` only yields keys that exist.
- `toSorted` replaces `sort()` only where it ran on a throwaway array (fresh from `map`/`filter`/`split`/`Object.entries`). The in-place mutation was already invisible, so this is strictly safer and behavior-identical.
- `at(-1)` replaces `arr[arr.length - 1]` only at sites already guarded by a `last && allLast && …` truthiness check, since `at` returns `T | undefined`. The one site in `_query.ts` that dereferences the result directly was left alone. Using `at(-1)!` there would be a downgrade, not a win.

`target` rises to ES2023 in `tsconfig.base.json` so the packages/workers context types `toSorted`; the app context already resolves an ESNext lib through Astro.

## Module Resolution

The second commit (isolated so it can be dropped on its own) swaps the legacy `node10` resolver for `bundler`, which understands `package.json` `exports`/`imports` maps. Everything here is bundled (Astro for the site, wrangler/esbuild for the workers) and the app already resolves with `bundler` via Astro, so this aligns the package and worker contexts. `module` becomes `ESNext` as `bundler` requires.

## Verification

CI is the gate. These could not be built or linted locally: the repo tracks a `node_modules` symlink pointing at its own absolute path, which resolves to a self-loop in any local checkout and makes `npm ci` fail with `ELOOP`. It is harmless on a fresh CI runner (the path is dangling, so `npm ci` removes and recreates it), which is why `main` stays green. Worth removing in a separate change, since it breaks local installs in every worktree.

The `bundler` resolution swap especially leans on CI's `astro check` and build, since a resolver change can surface new type errors that no other check would.
