### PR TITLE
refactor: move activity view types to a layer-neutral module

### DIFF
--- a/src/activity/types.ts
+++ b/src/activity/types.ts
@@ -1,0 +1,54 @@
+export interface Repo {
+  name: string;
+  owner: string;
+  description: string;
+  url: string;
+  primaryLanguage: {
+    name: string;
+    color: string;
+    extension: string | null;
+  } | null;
+  stargazerCount: number;
+  createdAt: string | null;
+  lastActivity: string;
+  activitySummary: {
+    prCount: number;
+    reviewCount: number;
+    issueCount: number;
+    mergeCount: number;
+    hasMergedPRs: boolean;
+  };
+  years: number[];
+}
+
+export interface Language {
+  name: string;
+  color: string;
+  extension: string | null;
+  count: number;
+}
+
+export interface YearCount {
+  year: number;
+  count: number;
+}
+
+export interface FilterState {
+  owner: "all" | "personal" | "external";
+  language: string | null;
+  search: string;
+  sort: "recent" | "active" | "stars" | "name";
+  year: number | null;
+}
+
+export interface ActivityState {
+  repos: Repo[];
+  cursor: string | null;
+  hasMore: boolean;
+  loading: boolean;
+  total: number;
+  filters: FilterState;
+  languages: Language[];
+  years: YearCount[];
+  currentYear: number | null;
+}

--- a/src/components/activity/ActivityTimeline.vue
+++ b/src/components/activity/ActivityTimeline.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
-import {
-  useActivityApi,
-  type Repo,
-  type YearCount,
-} from "./composables/useActivityApi";
+import { useActivityApi } from "./composables/useActivityApi";
+import type { Repo, YearCount } from "@/activity/types";
 import FilterControls from "./FilterControls.vue";
 import LanguageBar from "./LanguageBar.vue";
 import RepoCard from "./RepoCard.vue";

--- a/src/components/activity/FilterControls.vue
+++ b/src/components/activity/FilterControls.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { FilterState } from "./composables/useActivityApi";
+import type { FilterState } from "@/activity/types";
 
 const props = defineProps<{
   filters: FilterState;

--- a/src/components/activity/LanguageBar.vue
+++ b/src/components/activity/LanguageBar.vue
@@ -6,7 +6,7 @@ import {
   HoverCardPortal,
   HoverCardContent,
 } from "reka-ui";
-import type { Language } from "./composables/useActivityApi";
+import type { Language } from "@/activity/types";
 
 const OVERFLOW_THRESHOLD = 2;
 

--- a/src/components/activity/RepoCard.vue
+++ b/src/components/activity/RepoCard.vue
@@ -6,7 +6,7 @@ import {
   isYesterday,
   format,
 } from "date-fns";
-import type { Repo } from "./composables/useActivityApi";
+import type { Repo } from "@/activity/types";
 
 const props = defineProps<{
   repo: Repo;

--- a/src/components/activity/TimelineRail.vue
+++ b/src/components/activity/TimelineRail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import type { YearCount } from "./composables/useActivityApi";
+import type { YearCount } from "@/activity/types";
 
 const MAX_VISIBLE = 7;
 

--- a/src/components/activity/YearActivity.vue
+++ b/src/components/activity/YearActivity.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, watch } from "vue";
 import { actions } from "astro:actions";
-import type {
-  Repo,
-  Language,
-  YearCount,
-  FilterState,
-} from "@/activity/types";
+import type { Repo, Language, YearCount, FilterState } from "@/activity/types";
 import { debounce } from "./composables/useActivityApi";
 import FilterControls from "./FilterControls.vue";
 import LanguageBar from "./LanguageBar.vue";

--- a/src/components/activity/YearActivity.vue
+++ b/src/components/activity/YearActivity.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, watch } from "vue";
 import { actions } from "astro:actions";
-import {
-  type Repo,
-  type Language,
-  type YearCount,
-  type FilterState,
-  debounce,
-} from "./composables/useActivityApi";
+import type {
+  Repo,
+  Language,
+  YearCount,
+  FilterState,
+} from "@/activity/types";
+import { debounce } from "./composables/useActivityApi";
 import FilterControls from "./FilterControls.vue";
 import LanguageBar from "./LanguageBar.vue";
 import RepoCard from "./RepoCard.vue";

--- a/src/components/activity/composables/useActivityApi.ts
+++ b/src/components/activity/composables/useActivityApi.ts
@@ -1,60 +1,6 @@
 import { reactive, watch } from "vue";
 import { actions } from "astro:actions";
-
-export interface Repo {
-  name: string;
-  owner: string;
-  description: string;
-  url: string;
-  primaryLanguage: {
-    name: string;
-    color: string;
-    extension: string | null;
-  } | null;
-  stargazerCount: number;
-  createdAt: string | null;
-  lastActivity: string;
-  activitySummary: {
-    prCount: number;
-    reviewCount: number;
-    issueCount: number;
-    mergeCount: number;
-    hasMergedPRs: boolean;
-  };
-  years: number[];
-}
-
-export interface Language {
-  name: string;
-  color: string;
-  extension: string | null;
-  count: number;
-}
-
-export interface YearCount {
-  year: number;
-  count: number;
-}
-
-export interface FilterState {
-  owner: "all" | "personal" | "external";
-  language: string | null;
-  search: string;
-  sort: "recent" | "active" | "stars" | "name";
-  year: number | null;
-}
-
-export interface ActivityState {
-  repos: Repo[];
-  cursor: string | null;
-  hasMore: boolean;
-  loading: boolean;
-  total: number;
-  filters: FilterState;
-  languages: Language[];
-  years: YearCount[];
-  currentYear: number | null;
-}
+import type { Repo, FilterState, ActivityState } from "@/activity/types";
 
 export function debounce<T extends (...args: unknown[]) => void>(
   fn: T,

--- a/src/pages/activity/code.astro
+++ b/src/pages/activity/code.astro
@@ -3,7 +3,7 @@ import Layout from "../../layouts/Layout.astro";
 import Main from "../../layouts/Main.astro";
 import { SITE } from "../../config";
 import ActivityTimeline from "../../components/activity/ActivityTimeline.vue";
-import type { Repo } from "../../components/activity/composables/useActivityApi";
+import type { Repo } from "@/activity/types";
 import { getDb } from "@/db";
 import { queryRepos } from "./code/_query";
 import { formatReposMarkdown } from "./code/_markdown";

--- a/src/pages/activity/code/[year].astro
+++ b/src/pages/activity/code/[year].astro
@@ -4,7 +4,7 @@ import Layout from "../../../layouts/Layout.astro";
 import Main from "../../../layouts/Main.astro";
 import { SITE } from "../../../config";
 import YearActivity from "../../../components/activity/YearActivity.vue";
-import type { Repo, YearCount } from "../../../components/activity/composables/useActivityApi";
+import type { Repo, YearCount } from "@/activity/types";
 import { getDb } from "@/db";
 import { repoQuery, yearHaving, mapRepoRow, queryRepos } from "./_query";
 import { formatReposMarkdown } from "./_markdown";

--- a/src/pages/activity/code/_markdown.test.ts
+++ b/src/pages/activity/code/_markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { Repo } from "@/components/activity/composables/useActivityApi";
+import type { Repo } from "@/activity/types";
 import { formatReposMarkdown } from "./_markdown";
 
 const repo: Repo = {

--- a/src/pages/activity/code/_markdown.ts
+++ b/src/pages/activity/code/_markdown.ts
@@ -1,4 +1,4 @@
-import type { Repo } from "@/components/activity/composables/useActivityApi";
+import type { Repo } from "@/activity/types";
 
 export function formatReposMarkdown(
   repos: Repo[],

--- a/src/pages/activity/code/_query.ts
+++ b/src/pages/activity/code/_query.ts
@@ -1,7 +1,7 @@
 import { sql, type SqlBool } from "kysely";
 import type { Kysely, WhereInterface } from "kysely";
 import type { Database } from "@/db";
-import type { Repo } from "@/components/activity/composables/useActivityApi";
+import type { Repo } from "@/activity/types";
 import { SITE } from "@/config";
 
 export interface FilterParams {


### PR DESCRIPTION
Server-rendered code type-imported the activity view-model types (`Repo`, `Language`, `YearCount`, `FilterState`, `ActivityState`) from `src/components/activity/composables/useActivityApi.ts`, a Vue client module that pulls in `vue` and `astro:actions`. SSR routes under `src/pages/activity/code/` reached into client code just to name a data shape.

This moves the five interfaces into a layer-neutral `src/activity/types.ts` with zero runtime dependencies. The composable keeps its runtime `useActivityApi`/`debounce` exports and now type-imports the shapes it still references. Every importer, server and client, pulls the types from the new module; the two `.vue` files that still need runtime helpers keep importing those from the composable.

Pure type relocation, no behavior change. `npm run lint` and `npm test` (50 tests) pass.
