### PR TITLE
fix: type workers against generated env bindings

### DIFF
--- a/workers/github/main.ts
+++ b/workers/github/main.ts
@@ -1,9 +1,8 @@
 import { fetchGitHubActivity, type RepoActivity } from "@workspace/github";
 import { logger } from "@workspace/logger";
 
-interface Env {
+interface Env extends Cloudflare.Env {
   GITHUB_TOKEN: string;
-  ACTIVITY_DB: D1Database;
 }
 
 async function upsertActivityToD1(

--- a/workers/strava/main.ts
+++ b/workers/strava/main.ts
@@ -1,11 +1,8 @@
 import { Strava } from "strava";
 import { logger } from "@workspace/logger";
 
-export interface Env {
-  STRAVA_CLIENT_ID: string;
+interface Env extends Cloudflare.Env {
   STRAVA_CLIENT_SECRET: string;
-  STRAVA_USER_ID: string;
-  STRAVA_KV: KVNamespace;
 }
 
 interface StoredTokens {
@@ -16,7 +13,7 @@ interface StoredTokens {
 }
 
 async function getStravaClient(env: Env): Promise<Strava> {
-  const storedTokens = (await env.STRAVA_KV.get(
+  const storedTokens = (await env.KV.get(
     "tokens",
     "json",
   )) as StoredTokens | null;
@@ -33,7 +30,7 @@ async function getStravaClient(env: Env): Promise<Strava> {
       client_secret: env.STRAVA_CLIENT_SECRET,
       on_token_refresh: async (response) => {
         logger.info("Token refreshed automatically by Strava client");
-        await env.STRAVA_KV.put(
+        await env.KV.put(
           "tokens",
           JSON.stringify({
             access_token: response.access_token,
@@ -67,7 +64,7 @@ async function fetchStravaData(env: Env) {
     );
 
     // Store athlete data
-    await env.STRAVA_KV.put(
+    await env.KV.put(
       "athlete",
       JSON.stringify({
         ...athlete,
@@ -150,7 +147,7 @@ export default {
               client_secret: env.STRAVA_CLIENT_SECRET,
               on_token_refresh: async (response) => {
                 logger.info("Initial token received via OAuth");
-                await env.STRAVA_KV.put(
+                await env.KV.put(
                   "tokens",
                   JSON.stringify({
                     access_token: response.access_token,


### PR DESCRIPTION
Fixes a live bug in the Strava worker: KV reads and writes were hitting `undefined`.

The KV namespace is bound as `KV` in `workers/strava/wrangler.toml`, but `main.ts` hand-rolled its own `Env` interface declaring `STRAVA_KV: KVNamespace` and read/wrote `env.STRAVA_KV` in four places (the token read in `getStravaClient`, the `on_token_refresh` write, the athlete write in `fetchStravaData`, and the callback `on_token_refresh` write). At runtime `env.STRAVA_KV` was `undefined`, so every token and athlete read/write silently failed. Because the hand-rolled interface shadowed the generated env, the compiler never flagged the mismatch. All four now use `env.KV`.

## Seam Hardening

Both workers previously hand-declared their `Env` interface, which defeats the point of `wrangler types`: a binding rename in `wrangler.toml` wouldn't fail the build. Both now extend the generated `Cloudflare.Env` and declare only the secrets that aren't part of the generated env:

- strava: `interface Env extends Cloudflare.Env { STRAVA_CLIENT_SECRET: string }`. `KV`, `STRAVA_CLIENT_ID`, `STRAVA_USER_ID`, and `R2` come from the generated env.
- github: `interface Env extends Cloudflare.Env { GITHUB_TOKEN: string }`. `ACTIVITY_DB` comes from the generated env. No behavior change. The github worker already used the correct binding names.

A binding rename now breaks the type check instead of production.

## Out of scope

The `R2` binding in `workers/strava/wrangler.toml` is unused in code. Left as-is.

## Testing

`npm run lint` and `npm run test` (50 passing) both pass. Each worker type-checks clean against the generated env (`tsc --noEmit` per worker `tsconfig.json`). The full `npm run build` fails locally on the tracked self-referential `node_modules` symlink (a known repo-local issue unrelated to this change). Relying on CI for the full build.
