### PR TITLE
refactor: route activity reads through the query module

### DIFF
--- a/src/pages/activity/code/[year].astro
+++ b/src/pages/activity/code/[year].astro
@@ -1,12 +1,11 @@
 ---
-import { sql } from "kysely";
 import Layout from "../../../layouts/Layout.astro";
 import Main from "../../../layouts/Main.astro";
 import { SITE } from "../../../config";
 import YearActivity from "../../../components/activity/YearActivity.vue";
 import type { Repo, YearCount } from "../../../components/activity/composables/useActivityApi";
 import { getDb } from "@/db";
-import { repoQuery, yearHaving, mapRepoRow, queryRepos } from "./_query";
+import { queryRepos, queryYearsByLastActivity } from "./_query";
 import { formatReposMarkdown } from "./_markdown";
 import { logger } from "@workspace/logger";
 
@@ -35,45 +34,15 @@ let initialTotal = 0;
 let years: YearCount[] = [];
 
 try {
-  const countSubquery = db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .select("repos.id")
-    .groupBy("repos.id")
-    .having(yearHaving, "=", year);
-
-  const countResult = await db
-    .selectFrom(countSubquery.as("sub"))
-    .select(sql<number>`count(*)`.as("total"))
-    .executeTakeFirstOrThrow();
-  initialTotal = countResult.total;
-
-  if (initialTotal === 0) {
+  const data = await queryRepos(db, { year, all: true });
+  if (data.total === 0) {
     return Astro.redirect("/404");
   }
+  initialRepos = data.repos;
+  initialTotal = data.total;
 
-  const rows = await repoQuery(db)
-    .having(yearHaving, "=", year)
-    .orderBy(sql`last_activity`, "desc")
-    .execute();
-
-  initialRepos = rows.map(mapRepoRow);
-
-  const yearSubquery = db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .select([
-      "repos.id",
-      sql<number>`max(${sql.ref("repoActivity.year")})`.as("maxYear"),
-    ])
-    .groupBy("repos.id");
-
-  years = await db
-    .selectFrom(yearSubquery.as("sub"))
-    .select(["sub.maxYear as year", sql<number>`count(*)`.as("count")])
-    .groupBy("sub.maxYear")
-    .orderBy("sub.maxYear", "desc")
-    .execute();
+  const { years: yearRows } = await queryYearsByLastActivity(db);
+  years = yearRows;
 } catch (error) {
   logger.error({ error, year }, "Failed to load year activity data");
 }

--- a/src/pages/activity/code/_query.test.ts
+++ b/src/pages/activity/code/_query.test.ts
@@ -6,6 +6,8 @@ import {
   queryRepos,
   queryLanguages,
   queryYears,
+  queryYearsByLastActivity,
+  queryActivityTotals,
   InvalidCursorError,
 } from "./_query";
 
@@ -310,6 +312,40 @@ describe("queryRepos pagination", () => {
   });
 });
 
+describe("queryRepos all mode", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = createTestDb();
+    const repos: SeedRepo[] = Array.from({ length: 25 }, (_, i) => ({
+      owner: "bendrucker",
+      name: `repo-${String(i).padStart(2, "0")}`,
+      activity: [{ lastActivity: 1750000000 - i * 3600 }],
+    }));
+    repos.push({
+      owner: "bendrucker",
+      name: "prior-year",
+      activity: [{ lastActivity: 1718000000 }],
+    });
+    await seed(db, repos);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("returns every repo for the year with no pagination", async () => {
+    const data = await queryRepos(db, { year: 2025, all: true });
+    expect(data.repos).toHaveLength(25);
+    expect(data.total).toBe(25);
+    expect(data.hasMore).toBe(false);
+    expect(data.nextCursor).toBeNull();
+    expect(data.repos[0].name).toBe("repo-00");
+    expect(data.repos.at(-1)?.name).toBe("repo-24");
+    expect(data.repos.map((r) => r.name)).not.toContain("prior-year");
+  });
+});
+
 describe("queryLanguages", () => {
   let db: Kysely<Database>;
 
@@ -347,6 +383,14 @@ describe("queryLanguages", () => {
     expect(ts).toBeDefined();
     expect(ts!.extension).toBe(".ts");
   });
+
+  it("caps results with limit and keeps count-desc order", async () => {
+    const result = await queryLanguages(db, { limit: 2 });
+    expect(result.languages).toHaveLength(2);
+    const counts = result.languages.map((l) => l.count);
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+    expect(result.languages[0].name).toBe("TypeScript");
+  });
 });
 
 describe("queryYears", () => {
@@ -373,5 +417,113 @@ describe("queryYears", () => {
     expect(result.years.length).toBeGreaterThan(0);
     const years = result.years.map((y) => y.year);
     expect(years).not.toContain(2023);
+  });
+});
+
+describe("queryYearsByLastActivity", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = createTestDb();
+    await seed(db, [
+      {
+        owner: "bendrucker",
+        name: "long-lived",
+        activity: [
+          { lastActivity: 1686000000 },
+          { lastActivity: 1718000000 },
+          { lastActivity: 1750000000 },
+        ],
+      },
+      {
+        owner: "bendrucker",
+        name: "also-2025",
+        activity: [{ lastActivity: 1750000000 }],
+      },
+      {
+        owner: "bendrucker",
+        name: "peaked-2024",
+        activity: [{ lastActivity: 1686000000 }, { lastActivity: 1718000000 }],
+      },
+      {
+        owner: "bendrucker",
+        name: "only-2023",
+        activity: [{ lastActivity: 1686000000 }],
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("counts each repo once in its max year, descending", async () => {
+    const result = await queryYearsByLastActivity(db);
+    expect(result.years).toEqual([
+      { year: 2025, count: 2 },
+      { year: 2024, count: 1 },
+      { year: 2023, count: 1 },
+    ]);
+  });
+});
+
+describe("queryActivityTotals", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = createTestDb();
+    await seed(db, FIXTURES, LANGUAGE_EXTENSIONS);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("sums activity across all repos", async () => {
+    const totals = await queryActivityTotals(db);
+    expect(totals.repos).toBe(6);
+    expect(totals.prs).toBe(28);
+    expect(totals.reviews).toBe(15);
+    expect(totals.issues).toBe(12);
+    expect(totals.years).toBe(3);
+  });
+
+  it("returns zeros on an empty database", async () => {
+    const emptyDb = createTestDb();
+    try {
+      const totals = await queryActivityTotals(emptyDb);
+      expect(totals).toEqual({
+        repos: 0,
+        prs: 0,
+        reviews: 0,
+        issues: 0,
+        years: 0,
+      });
+    } finally {
+      await emptyDb.destroy();
+    }
+  });
+
+  it("counts distinct repos and years", async () => {
+    const multiDb = createTestDb();
+    try {
+      await seed(multiDb, [
+        {
+          owner: "bendrucker",
+          name: "long-lived",
+          activity: [
+            { lastActivity: 1686000000, prCount: 1 },
+            { lastActivity: 1718000000, prCount: 2 },
+            { lastActivity: 1750000000, prCount: 3 },
+          ],
+        },
+      ]);
+      const totals = await queryActivityTotals(multiDb);
+      expect(totals.repos).toBe(1);
+      expect(totals.years).toBe(3);
+      expect(totals.prs).toBe(6);
+    } finally {
+      await multiDb.destroy();
+    }
   });
 });

--- a/src/pages/activity/code/_query.ts
+++ b/src/pages/activity/code/_query.ts
@@ -168,12 +168,14 @@ export interface ReposInput {
   language?: string | null;
   search?: string | null;
   year?: number | null;
+  all?: boolean;
 }
 
 export interface LanguagesInput {
   owner?: "personal" | "external" | null;
   search?: string | null;
   year?: number | null;
+  limit?: number;
 }
 
 export interface YearsInput {
@@ -216,6 +218,16 @@ export async function queryRepos(db: Kysely<Database>, input: ReposInput) {
     .executeTakeFirstOrThrow();
 
   const total = countResult.total;
+
+  if (input.all === true) {
+    const rows = await repoQuery(db)
+      .$call(applyFilters(filters))
+      .$if(!!filters.year, (qb) => qb.having(yearHaving, "=", filters.year!))
+      .orderBy(sql`last_activity`, "desc")
+      .execute();
+    const repos = rows.map(mapRepoRow);
+    return { repos, nextCursor: null, hasMore: false, total };
+  }
 
   let query = repoQuery(db)
     .$call(applyFilters(filters))
@@ -320,6 +332,7 @@ export async function queryLanguages(
     ])
     .groupBy("sub.primaryLanguageName")
     .orderBy(sql`count`, "desc")
+    .$if(input.limit != null, (qb) => qb.limit(input.limit!))
     .execute();
 
   const total = rows.reduce((sum, row) => sum + row.count, 0);
@@ -350,4 +363,44 @@ export async function queryYears(db: Kysely<Database>, input: YearsInput) {
     .execute();
 
   return { years: rows };
+}
+
+export async function queryYearsByLastActivity(db: Kysely<Database>) {
+  const subquery = db
+    .selectFrom("repos")
+    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
+    .select([
+      "repos.id",
+      sql<number>`max(${sql.ref("repoActivity.year")})`.as("maxYear"),
+    ])
+    .groupBy("repos.id");
+
+  const rows = await db
+    .selectFrom(subquery.as("sub"))
+    .select(["sub.maxYear as year", sql<number>`count(*)`.as("count")])
+    .groupBy("sub.maxYear")
+    .orderBy("sub.maxYear", "desc")
+    .execute();
+
+  return { years: rows };
+}
+
+export async function queryActivityTotals(db: Kysely<Database>) {
+  return db
+    .selectFrom("repos")
+    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
+    .select([
+      sql<number>`count(distinct ${sql.ref("repos.id")})`.as("repos"),
+      sql<number>`coalesce(sum(${sql.ref("repoActivity.prCount")}), 0)`.as(
+        "prs",
+      ),
+      sql<number>`coalesce(sum(${sql.ref("repoActivity.reviewCount")}), 0)`.as(
+        "reviews",
+      ),
+      sql<number>`coalesce(sum(${sql.ref("repoActivity.issueCount")}), 0)`.as(
+        "issues",
+      ),
+      sql<number>`count(distinct ${sql.ref("repoActivity.year")})`.as("years"),
+    ])
+    .executeTakeFirstOrThrow();
 }

--- a/src/pages/activity/code/og.png.ts
+++ b/src/pages/activity/code/og.png.ts
@@ -1,52 +1,23 @@
 import type { APIRoute } from "astro";
-import { sql } from "kysely";
 import { getDb } from "@/db";
 import { generateOgImageForActivity } from "@/og/generate";
+import { queryActivityTotals, queryLanguages } from "./_query";
 
 export const GET: APIRoute = async () => {
   const db = await getDb();
 
-  const stats = await db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .select([
-      sql<number>`count(distinct ${sql.ref("repos.id")})`.as("repos"),
-      sql<number>`coalesce(sum(${sql.ref("repoActivity.prCount")}), 0)`.as(
-        "prs",
-      ),
-      sql<number>`coalesce(sum(${sql.ref("repoActivity.reviewCount")}), 0)`.as(
-        "reviews",
-      ),
-      sql<number>`coalesce(sum(${sql.ref("repoActivity.issueCount")}), 0)`.as(
-        "issues",
-      ),
-      sql<number>`count(distinct ${sql.ref("repoActivity.year")})`.as("years"),
-    ])
-    .executeTakeFirstOrThrow();
-
-  const languages = await db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .where("repos.primaryLanguageName", "is not", null)
-    .select([
-      "repos.primaryLanguageName as name",
-      "repos.primaryLanguageColor as color",
-      sql<number>`count(distinct ${sql.ref("repos.id")})`.as("count"),
-    ])
-    .groupBy("repos.primaryLanguageName")
-    .orderBy(sql`count`, "desc")
-    .limit(6)
-    .execute();
+  const totals = await queryActivityTotals(db);
+  const { languages } = await queryLanguages(db, { limit: 6 });
 
   const png = await generateOgImageForActivity({
-    repos: stats.repos,
-    prs: stats.prs,
-    reviews: stats.reviews,
-    issues: stats.issues,
-    years: stats.years,
+    repos: totals.repos,
+    prs: totals.prs,
+    reviews: totals.reviews,
+    issues: totals.issues,
+    years: totals.years,
     languages: languages.map((l) => ({
-      name: l.name!,
-      color: l.color!,
+      name: l.name,
+      color: l.color,
       count: l.count,
     })),
   });


### PR DESCRIPTION
Two callers hand-wrote their own SQL against the activity tables and bypassed `_query.ts`, the tested module every other read goes through. This moves that SQL into `_query.ts` so there is one place that knows how to read activity data. Behavior is preserved exactly. Nothing the pages render changes.

## Changes

`_query.ts` gains everything the two callers needed:

- An `all` mode on `queryRepos`. When `all: true`, it computes `total` the same way the paginated path does, then returns every matching row ordered by `last_activity desc` with `nextCursor: null` and `hasMore: false`. This is an early return before the sort switch, so the paginated path is untouched.
- `queryYearsByLastActivity`, which groups each repo by its max activity year and counts repos per max-year. This is deliberately distinct from `queryYears` (see below).
- `queryActivityTotals`, the whole-site aggregate (distinct repos, summed PR/review/issue counts, distinct years).
- A `limit` option on `queryLanguages`, applied to the outer languages query only. It is a query option, not a filter, so it is not part of `toFilterParams`.

`[year].astro` drops its inline count, repo, and years queries and calls `queryRepos(db, { year, all: true })` plus `queryYearsByLastActivity`. The year page seeds all repos for the year (the Vue component renders `initialRepos` verbatim and does not paginate on mount), so `all` mode is required rather than a single page. The `text/markdown` path is unchanged.

`og.png.ts` drops its inline aggregate and languages queries for `queryActivityTotals` and `queryLanguages({ limit: 6 })`.

## Notes for review

- **`queryLanguages` filters on `primaryLanguageColor is not null`; og's inline query did not.** Immaterial in practice: GitHub returns a color whenever a repo has a primary language, so the two produce the same rows. Calling it out because it is a technically-wider filter than the code being replaced.
- **The year-page footer nav keeps max-year semantics; the timeline's year filter keeps active-per-year semantics.** `queryYearsByLastActivity` counts each repo once, in its most recent year, which is what the `[year]` footer nav has always shown. `queryYears` counts a repo in every year it was active, which is what the timeline filter uses. This divergence predates this PR and is intentionally left as-is here, not resolved.

## Testing

`npm run test` passes (56 tests). New cases cover `queryActivityTotals` (sums, `coalesce` zero on an empty DB, distinct repo/year counting), `queryRepos` `all` mode (more than one page of repos returned in full, `hasMore`/`nextCursor` unset), `queryYearsByLastActivity` (a repo active across years counted once in its max year, descending order), and `queryLanguages` with `limit`.

`npm run lint` passes. Local `npm run build` fails while resolving the parent repo's tsconfig against a deleted `node_modules` symlink, a known repo-local environment issue unrelated to these changes; relying on CI for the build.
