### PR TITLE
fix: type workers against generated env bindings

### DIFF
--- a/workers/github/main.ts
+++ b/workers/github/main.ts
@@ -5,10 +5,9 @@ import { createDb } from "../../src/db";
 import { upsertRepo, upsertActivity } from "../../src/activity/upsert";
 import { fetchGitHubActivityWithConfig } from "../../src/services/github";
 
-interface Env {
+type Env = Required<Cloudflare.Env> & {
   GITHUB_TOKEN: string;
-  ACTIVITY_DB: D1Database;
-}
+};
 
 const BATCH_SIZE = 500;
 

--- a/workers/strava/main.ts
+++ b/workers/strava/main.ts
@@ -1,12 +1,9 @@
 import { Strava } from "strava";
 import { logger } from "@workspace/logger";
 
-export interface Env {
-  STRAVA_CLIENT_ID: string;
+type Env = Required<Cloudflare.Env> & {
   STRAVA_CLIENT_SECRET: string;
-  STRAVA_USER_ID: string;
-  STRAVA_KV: KVNamespace;
-}
+};
 
 interface StoredTokens {
   access_token: string;
@@ -16,7 +13,7 @@ interface StoredTokens {
 }
 
 async function getStravaClient(env: Env): Promise<Strava> {
-  const storedTokens = (await env.STRAVA_KV.get(
+  const storedTokens = (await env.KV.get(
     "tokens",
     "json",
   )) as StoredTokens | null;
@@ -33,7 +30,7 @@ async function getStravaClient(env: Env): Promise<Strava> {
       client_secret: env.STRAVA_CLIENT_SECRET,
       on_token_refresh: async (response) => {
         logger.info("Token refreshed automatically by Strava client");
-        await env.STRAVA_KV.put(
+        await env.KV.put(
           "tokens",
           JSON.stringify({
             access_token: response.access_token,
@@ -67,7 +64,7 @@ async function fetchStravaData(env: Env) {
     );
 
     // Store athlete data
-    await env.STRAVA_KV.put(
+    await env.KV.put(
       "athlete",
       JSON.stringify({
         ...athlete,
@@ -150,7 +147,7 @@ export default {
               client_secret: env.STRAVA_CLIENT_SECRET,
               on_token_refresh: async (response) => {
                 logger.info("Initial token received via OAuth");
-                await env.STRAVA_KV.put(
+                await env.KV.put(
                   "tokens",
                   JSON.stringify({
                     access_token: response.access_token,


### PR DESCRIPTION
Fixes a live runtime bug in the Strava worker. `wrangler.toml` binds KV as `binding = "KV"`, so the binding is reachable at `env.KV`. The worker hand-declared `interface Env { STRAVA_KV: KVNamespace }` and read and wrote `env.STRAVA_KV` in four places (the token read and its refresh write in `getStravaClient`, the athlete write in `fetchStravaData`, and the callback refresh write). `env.STRAVA_KV` was `undefined` at runtime, so every Strava token and athlete KV write silently hit `undefined`. All four sites now use `env.KV`.

Both workers also dropped their hand-rolled `interface Env`, which duplicated binding names by hand and defeated the generated types. They now derive bindings from the generated `Cloudflare.Env` and declare only secrets (`STRAVA_CLIENT_SECRET`, `GITHUB_TOKEN`), which are not part of the generated env, via intersection. A binding rename in `wrangler.toml` now fails the build instead of drifting silently. The github worker already used correct names, so this is a no-op there beyond hardening the seam.

The env type wraps `Cloudflare.Env` in `Required<>`. When CI runs `wrangler types` fresh, the generated bindings are marked optional (`KV?`, `R2?`), which a bare `Cloudflare.Env` would surface as "possibly undefined" errors. Bindings are guaranteed present at runtime, so stripping the optionality is correct.

The unused `R2` binding on the Strava worker is out of scope and left untouched.

Verified per worker with the exact CI command (`wrangler types` then `tsc --noEmit`) against freshly regenerated optional types, so the check matches what CI runs rather than the stale committed types. Both workers typecheck clean. Repo lint and the test suite pass.
