### PR TITLE
refactor: route activity reads through the query module

### DIFF
--- a/src/pages/activity/code/[year].astro
+++ b/src/pages/activity/code/[year].astro
@@ -1,19 +1,22 @@
 ---
-import { sql } from "kysely";
 import Layout from "../../../layouts/Layout.astro";
 import Main from "../../../layouts/Main.astro";
 import { SITE } from "../../../config";
 import YearActivity from "../../../components/activity/YearActivity.vue";
 import type { Repo, YearCount } from "@/activity/types";
 import { getDb } from "@/db";
-import { repoQuery, yearHaving, mapRepoRow, queryRepos } from "./_query";
+import { queryRepos, queryYearsByLastActivity } from "./_query";
 import { formatReposMarkdown } from "./_markdown";
 import { logger } from "@workspace/logger";
 
 const { year: yearParam } = Astro.params;
 const year = Number(yearParam);
 
-if (!Number.isInteger(year) || year < 2000 || year > new Date().getFullYear() + 1) {
+if (
+  !Number.isInteger(year) ||
+  year < 2000 ||
+  year > new Date().getFullYear() + 1
+) {
   return Astro.redirect("/404");
 }
 
@@ -35,45 +38,17 @@ let initialTotal = 0;
 let years: YearCount[] = [];
 
 try {
-  const countSubquery = db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .select("repos.id")
-    .groupBy("repos.id")
-    .having(yearHaving, "=", year);
+  const data = await queryRepos(db, { year, all: true });
 
-  const countResult = await db
-    .selectFrom(countSubquery.as("sub"))
-    .select(sql<number>`count(*)`.as("total"))
-    .executeTakeFirstOrThrow();
-  initialTotal = countResult.total;
-
-  if (initialTotal === 0) {
+  if (data.total === 0) {
     return Astro.redirect("/404");
   }
 
-  const rows = await repoQuery(db)
-    .having(yearHaving, "=", year)
-    .orderBy(sql`last_activity`, "desc")
-    .execute();
+  initialRepos = data.repos;
+  initialTotal = data.total;
 
-  initialRepos = rows.map(mapRepoRow);
-
-  const yearSubquery = db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .select([
-      "repos.id",
-      sql<number>`max(${sql.ref("repoActivity.year")})`.as("maxYear"),
-    ])
-    .groupBy("repos.id");
-
-  years = await db
-    .selectFrom(yearSubquery.as("sub"))
-    .select(["sub.maxYear as year", sql<number>`count(*)`.as("count")])
-    .groupBy("sub.maxYear")
-    .orderBy("sub.maxYear", "desc")
-    .execute();
+  const { years: yearRows } = await queryYearsByLastActivity(db);
+  years = yearRows;
 } catch (error) {
   logger.error({ error, year }, "Failed to load year activity data");
 }
@@ -82,8 +57,16 @@ const title = `GitHub Activity: ${year} | ${SITE.title}`;
 const description = `${initialTotal} repositories ${SITE.author} last contributed to in ${year}.`;
 ---
 
-<Layout title={title} description={description} ogImage="/activity/code/og.png" sourcePath="src/pages/activity/code/[year].astro">
-  <Main pageTitle={`Activity: Code (${year})`} pageDesc={`Repositories last contributed to in ${year}.`}>
+<Layout
+  title={title}
+  description={description}
+  ogImage="/activity/code/og.png"
+  sourcePath="src/pages/activity/code/[year].astro"
+>
+  <Main
+    pageTitle={`Activity: Code (${year})`}
+    pageDesc={`Repositories last contributed to in ${year}.`}
+  >
     <section>
       <YearActivity
         client:load

--- a/src/pages/activity/code/_query.test.ts
+++ b/src/pages/activity/code/_query.test.ts
@@ -6,6 +6,8 @@ import {
   queryRepos,
   queryLanguages,
   queryYears,
+  queryYearsByLastActivity,
+  queryActivityTotals,
   InvalidCursorError,
 } from "./_query";
 
@@ -373,5 +375,158 @@ describe("queryYears", () => {
     expect(result.years.length).toBeGreaterThan(0);
     const years = result.years.map((y) => y.year);
     expect(years).not.toContain(2023);
+  });
+});
+
+const TS_2023 = 1680000000;
+const TS_2024 = 1710000000;
+const TS_2025 = 1740000000;
+
+describe("queryLanguages with limit", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = createTestDb();
+    await seed(db, FIXTURES, LANGUAGE_EXTENSIONS);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("caps results while keeping count-descending order", async () => {
+    const all = await queryLanguages(db, {});
+    expect(all.languages.length).toBeGreaterThan(2);
+
+    const limited = await queryLanguages(db, { limit: 2 });
+    expect(limited.languages).toHaveLength(2);
+    expect(limited.languages[0].name).toBe("TypeScript");
+    expect(limited.languages[0].count).toBe(2);
+    const counts = limited.languages.map((l) => l.count);
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+  });
+});
+
+describe("queryActivityTotals", () => {
+  let db: Kysely<Database>;
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("coalesces to zero on an empty database", async () => {
+    db = createTestDb();
+    const totals = await queryActivityTotals(db);
+    expect(totals).toEqual({
+      repos: 0,
+      prs: 0,
+      reviews: 0,
+      issues: 0,
+      years: 0,
+    });
+  });
+
+  it("sums counts and counts distinct repos and years", async () => {
+    db = createTestDb();
+    await seed(db, [
+      {
+        owner: "bendrucker",
+        name: "multi-year",
+        activity: [
+          {
+            lastActivity: TS_2024,
+            prCount: 5,
+            reviewCount: 2,
+            issueCount: 1,
+          },
+          {
+            lastActivity: TS_2025,
+            prCount: 10,
+            reviewCount: 3,
+            issueCount: 2,
+          },
+        ],
+      },
+      {
+        owner: "bendrucker",
+        name: "single-year",
+        activity: [
+          {
+            lastActivity: TS_2025,
+            prCount: 1,
+            reviewCount: 1,
+            issueCount: 1,
+          },
+        ],
+      },
+    ]);
+
+    const totals = await queryActivityTotals(db);
+    expect(totals.repos).toBe(2);
+    expect(totals.prs).toBe(16);
+    expect(totals.reviews).toBe(6);
+    expect(totals.issues).toBe(4);
+    expect(totals.years).toBe(2);
+  });
+});
+
+describe("queryRepos all mode", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = createTestDb();
+    const repos: SeedRepo[] = Array.from({ length: 25 }, (_, i) => ({
+      owner: "bendrucker",
+      name: `repo-${String(i).padStart(2, "0")}`,
+      activity: [{ lastActivity: TS_2025 + i * 3600 }],
+    }));
+    await seed(db, repos);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("returns every repo for the year without paginating", async () => {
+    const result = await queryRepos(db, { year: 2025, all: true });
+    expect(result.repos).toHaveLength(25);
+    expect(result.total).toBe(25);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+  });
+});
+
+describe("queryYearsByLastActivity", () => {
+  let db: Kysely<Database>;
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("counts each repo once in its max year, ordered descending", async () => {
+    db = createTestDb();
+    await seed(db, [
+      {
+        owner: "bendrucker",
+        name: "spans-years",
+        activity: [{ lastActivity: TS_2023 }, { lastActivity: TS_2025 }],
+      },
+      {
+        owner: "bendrucker",
+        name: "mid",
+        activity: [{ lastActivity: TS_2024 }],
+      },
+      {
+        owner: "bendrucker",
+        name: "recent",
+        activity: [{ lastActivity: TS_2025 }],
+      },
+    ]);
+
+    const { years } = await queryYearsByLastActivity(db);
+    expect(years).toEqual([
+      { year: 2025, count: 2 },
+      { year: 2024, count: 1 },
+    ]);
   });
 });

--- a/src/pages/activity/code/_query.ts
+++ b/src/pages/activity/code/_query.ts
@@ -168,12 +168,14 @@ export interface ReposInput {
   language?: string | null;
   search?: string | null;
   year?: number | null;
+  all?: boolean;
 }
 
 export interface LanguagesInput {
   owner?: "personal" | "external" | null;
   search?: string | null;
   year?: number | null;
+  limit?: number;
 }
 
 export interface YearsInput {
@@ -216,6 +218,16 @@ export async function queryRepos(db: Kysely<Database>, input: ReposInput) {
     .executeTakeFirstOrThrow();
 
   const total = countResult.total;
+
+  if (input.all === true) {
+    const rows = await repoQuery(db)
+      .$call(applyFilters(filters))
+      .$if(!!filters.year, (qb) => qb.having(yearHaving, "=", filters.year!))
+      .orderBy(sql`last_activity`, "desc")
+      .execute();
+    const repos = rows.map(mapRepoRow);
+    return { repos, nextCursor: null, hasMore: false, total };
+  }
 
   let query = repoQuery(db)
     .$call(applyFilters(filters))
@@ -320,6 +332,7 @@ export async function queryLanguages(
     ])
     .groupBy("sub.primaryLanguageName")
     .orderBy(sql`count`, "desc")
+    .$if(input.limit != null, (qb) => qb.limit(input.limit!))
     .execute();
 
   const total = rows.reduce((sum, row) => sum + row.count, 0);
@@ -350,4 +363,44 @@ export async function queryYears(db: Kysely<Database>, input: YearsInput) {
     .execute();
 
   return { years: rows };
+}
+
+export async function queryYearsByLastActivity(db: Kysely<Database>) {
+  const subquery = db
+    .selectFrom("repos")
+    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
+    .select([
+      "repos.id",
+      sql<number>`max(${sql.ref("repoActivity.year")})`.as("maxYear"),
+    ])
+    .groupBy("repos.id");
+
+  const rows = await db
+    .selectFrom(subquery.as("sub"))
+    .select(["sub.maxYear as year", sql<number>`count(*)`.as("count")])
+    .groupBy("sub.maxYear")
+    .orderBy("sub.maxYear", "desc")
+    .execute();
+
+  return { years: rows };
+}
+
+export async function queryActivityTotals(db: Kysely<Database>) {
+  return db
+    .selectFrom("repos")
+    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
+    .select([
+      sql<number>`count(distinct ${sql.ref("repos.id")})`.as("repos"),
+      sql<number>`coalesce(sum(${sql.ref("repoActivity.prCount")}), 0)`.as(
+        "prs",
+      ),
+      sql<number>`coalesce(sum(${sql.ref("repoActivity.reviewCount")}), 0)`.as(
+        "reviews",
+      ),
+      sql<number>`coalesce(sum(${sql.ref("repoActivity.issueCount")}), 0)`.as(
+        "issues",
+      ),
+      sql<number>`count(distinct ${sql.ref("repoActivity.year")})`.as("years"),
+    ])
+    .executeTakeFirstOrThrow();
 }

--- a/src/pages/activity/code/og.png.ts
+++ b/src/pages/activity/code/og.png.ts
@@ -1,52 +1,24 @@
 import type { APIRoute } from "astro";
-import { sql } from "kysely";
 import { getDb } from "@/db";
 import { generateOgImageForActivity } from "@/og/generate";
+import { queryActivityTotals, queryLanguages } from "./_query";
 
 export const GET: APIRoute = async () => {
   const db = await getDb();
 
-  const stats = await db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .select([
-      sql<number>`count(distinct ${sql.ref("repos.id")})`.as("repos"),
-      sql<number>`coalesce(sum(${sql.ref("repoActivity.prCount")}), 0)`.as(
-        "prs",
-      ),
-      sql<number>`coalesce(sum(${sql.ref("repoActivity.reviewCount")}), 0)`.as(
-        "reviews",
-      ),
-      sql<number>`coalesce(sum(${sql.ref("repoActivity.issueCount")}), 0)`.as(
-        "issues",
-      ),
-      sql<number>`count(distinct ${sql.ref("repoActivity.year")})`.as("years"),
-    ])
-    .executeTakeFirstOrThrow();
+  const totals = await queryActivityTotals(db);
 
-  const languages = await db
-    .selectFrom("repos")
-    .innerJoin("repoActivity", "repoActivity.repoId", "repos.id")
-    .where("repos.primaryLanguageName", "is not", null)
-    .select([
-      "repos.primaryLanguageName as name",
-      "repos.primaryLanguageColor as color",
-      sql<number>`count(distinct ${sql.ref("repos.id")})`.as("count"),
-    ])
-    .groupBy("repos.primaryLanguageName")
-    .orderBy(sql`count`, "desc")
-    .limit(6)
-    .execute();
+  const { languages } = await queryLanguages(db, { limit: 6 });
 
   const png = await generateOgImageForActivity({
-    repos: stats.repos,
-    prs: stats.prs,
-    reviews: stats.reviews,
-    issues: stats.issues,
-    years: stats.years,
+    repos: totals.repos,
+    prs: totals.prs,
+    reviews: totals.reviews,
+    issues: totals.issues,
+    years: totals.years,
     languages: languages.map((l) => ({
-      name: l.name!,
-      color: l.color!,
+      name: l.name,
+      color: l.color,
       count: l.count,
     })),
   });


### PR DESCRIPTION
Routes every activity DB read through `src/pages/activity/code/_query.ts`, the tested query module. Two callers hand-wrote their own SQL and bypassed it: `src/pages/activity/code/[year].astro` and `src/pages/activity/code/og.png.ts`. That SQL now lives in `_query.ts`, so the query surface has one home and stays under test. Behavior is preserved.

To keep the callers' behavior identical, `_query.ts` gains:

- `all` mode on `queryRepos` (`{ year, all: true }`) returns every matching row for the year with no pagination, ordered by `last_activity desc` only (no id tiebreaker), matching the year page's old inline query exactly. The year page needs this because `YearActivity.vue` renders `initialRepos` verbatim and does not paginate on mount, so it must be seeded with all repos for the year, not one page. The paginated path is untouched (early return before the sort switch).
- `queryYearsByLastActivity` moves the year-nav counts subquery: group each repo by its max active year, then count repos per max-year, descending.
- `queryActivityTotals` moves og's whole-site aggregate (distinct repos, summed PR/review/issue counts, distinct years).
- `limit` option on `queryLanguages`, applied to the final languages query. og passes `limit: 6` for its top languages.

## Behavior Notes

- `queryLanguages` filters `primary_language_color is not null`; og's inline languages query did not. Immaterial in practice (every seeded language carries a color), called out for completeness.
- The year-page footer nav keeps max-year semantics via `queryYearsByLastActivity` (each repo counted once, in its most recent active year), while the timeline year filter uses `queryYears`, which counts repos active per year. This divergence is pre-existing and intentional; left as-is.

## Testing

Extends `_query.test.ts` against the in-memory SQLite harness:

- `queryActivityTotals`: sums across repos and years, coalesces to zero on an empty DB, and counts distinct repos and years (repo seeded active across two years).
- `queryRepos(db, { year, all: true })`: seeds more than one page of repos in a year and asserts every one is returned with `hasMore === false`, `nextCursor === null`, and the correct `total`.
- `queryYearsByLastActivity`: a repo active across years is counted once in its max year, in descending order with correct counts.
- `queryLanguages` with `limit`: caps results while keeping count-descending order.

`astro check` runs in CI. `npm run build` is not runnable in this worktree due to the known `node_modules` symlink issue at `astro sync`.
