### PR TITLE
chore: add greptile config

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,3 @@
+{
+  "strictness": 2
+}


### PR DESCRIPTION
Adds a `.greptile/config.json` matching the strictness setting used in the claude repo.