### PR TITLE
Footer redesign: split row

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,26 +17,21 @@ const sourceUrl = sourcePath ? `${SITE.viewSource.url}${sourcePath}` : undefined
 <footer class:list={["w-full", { "mt-auto": !noMarginTop }]}>
   <Hr noPadding />
   <div
-    class="flex flex-col items-center justify-between py-6 sm:flex-row-reverse sm:py-4"
+    class="flex flex-col items-start justify-between gap-2 py-4 sm:flex-row sm:items-center"
   >
-    <Socials centered />
-    <div class="my-2 flex flex-col items-center whitespace-nowrap sm:flex-row">
-      <span>Copyright &#169; {currentYear}</span>
-      <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
-      <span>All rights reserved.</span>
+    <div class="flex flex-col gap-0.5 text-xs text-foreground/60">
+      <span>&#169; {currentYear} Ben Drucker</span>
       {sourceUrl && (
-        <>
-          <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
-          <a
-            href={sourceUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-accent"
-          >
-            {SITE.viewSource.text}
-          </a>
-        </>
+        <a
+          href={sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-accent"
+        >
+          {SITE.viewSource.text}
+        </a>
       )}
     </div>
+    <Socials centered />
   </div>
 </footer>

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -9,15 +9,15 @@ export interface Props {
 const { centered = false } = Astro.props;
 ---
 
-<div class:list={["flex-wrap justify-center gap-1", { flex: centered }]}>
+<div class:list={["flex-wrap justify-center gap-0.5", { flex: centered }]}>
   {
     SOCIALS.map(social => (
       <LinkButton
         href={social.href}
-        class="p-2 hover:rotate-6 sm:p-1"
+        class="p-1.5 text-foreground/60 hover:rotate-6"
         title={social.linkTitle}
       >
-        <social.icon class="inline-block size-6 scale-125 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent sm:scale-110" />
+        <social.icon class="inline-block size-5 fill-transparent stroke-current stroke-2 group-hover:fill-transparent" />
         <span class="sr-only">{social.linkTitle}</span>
       </LinkButton>
     ))


### PR DESCRIPTION
Refines the footer into a single horizontal row on sm+ screens: small, dimmed copyright on the left and social icons on the right (removing the prior reversed layout). Below sm, the two stack left-aligned.

Copyright drops the pipe-separated "All rights reserved." formatting for a plain "© {year} Ben Drucker" line plus a subtle view-source link. Text and icons share the same text-foreground/60 dim level for equal visual weight; icons shrink to size-5 and lose the scale/opacity emphasis.