### PR TITLE
Footer redesign: compact inline

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,16 +17,15 @@ const sourceUrl = sourcePath ? `${SITE.viewSource.url}${sourcePath}` : undefined
 <footer class:list={["w-full", { "mt-auto": !noMarginTop }]}>
   <Hr noPadding />
   <div
-    class="flex flex-col items-center justify-between py-6 sm:flex-row-reverse sm:py-4"
+    class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 py-3"
   >
-    <Socials centered />
-    <div class="my-2 flex flex-col items-center whitespace-nowrap sm:flex-row">
-      <span>Copyright &#169; {currentYear}</span>
-      <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
-      <span>All rights reserved.</span>
+    <div
+      class="flex items-center gap-1.5 whitespace-nowrap text-xs text-foreground/50"
+    >
+      <span>&#169; {currentYear} Ben Drucker</span>
       {sourceUrl && (
         <>
-          <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
+          <span aria-hidden="true">&middot;</span>
           <a
             href={sourceUrl}
             target="_blank"
@@ -38,5 +37,6 @@ const sourceUrl = sourcePath ? `${SITE.viewSource.url}${sourcePath}` : undefined
         </>
       )}
     </div>
+    <Socials centered />
   </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@ const sourceUrl = sourcePath ? `${SITE.viewSource.url}${sourcePath}` : undefined
 <footer class:list={["w-full", { "mt-auto": !noMarginTop }]}>
   <Hr noPadding />
   <div
-    class="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 py-3"
+    class="flex flex-col-reverse items-center gap-y-1 py-3 sm:flex-row sm:flex-wrap sm:justify-between sm:gap-x-3"
   >
     <div
       class="flex items-center gap-1.5 whitespace-nowrap text-xs text-foreground/50"

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -9,15 +9,15 @@ export interface Props {
 const { centered = false } = Astro.props;
 ---
 
-<div class:list={["flex-wrap justify-center gap-1", { flex: centered }]}>
+<div class:list={["flex-wrap justify-center gap-0.5", { flex: centered }]}>
   {
     SOCIALS.map(social => (
       <LinkButton
         href={social.href}
-        class="p-2 hover:rotate-6 sm:p-1"
+        class="p-1 text-foreground/50 hover:rotate-6"
         title={social.linkTitle}
       >
-        <social.icon class="inline-block size-6 scale-125 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent sm:scale-110" />
+        <social.icon class="inline-block size-4 fill-transparent stroke-current stroke-2 group-hover:fill-transparent" />
         <span class="sr-only">{social.linkTitle}</span>
       </LinkButton>
     ))


### PR DESCRIPTION
Replaces the stacked, heavier footer with a compact single line. Copyright leads on the left (`© {year} Ben Drucker`, then a middot and the view-source link), social icons trail on the right. Text and icons share one dim weight (`text-foreground/50`) and shrink to `text-xs` / `size-4`. Gone: the pipe separators, "All rights reserved," and the `scale-125` / `opacity-90` icon emphasis.

The row is monospace, so on phones five icons plus the copyright run past a ~360px content area and the inline layout can't hold one line. Below `sm` the footer stacks into two centered rows instead: icons on top, copyright and view-source link beneath. At `sm` and up it stays the single inline row.
