### PR TITLE
fix(eslint): pin tsconfigRootDir and ignore .worktrees

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,9 @@ export default [
   ...eslintPluginAstro.configs.recommended,
   {
     languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
       globals: {
         ...globals.browser,
         ...globals.node,
@@ -18,6 +21,7 @@ export default [
     ignores: [
       "dist/**",
       ".astro",
+      ".worktrees/**",
       "public/pagefind/**",
       "**/worker-configuration.d.ts",
     ],


### PR DESCRIPTION
## What

- Pin `parserOptions.tsconfigRootDir` to the config directory.
- Add `.worktrees/**` to ESLint `ignores`.

## Why

When git worktrees coexist under `.worktrees/` (stacked PRs, parallel background agents), typescript-eslint discovers multiple candidate TSConfig roots and fails **every** file with:

> Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present

This breaks `npm run lint` repo-wide whenever more than one worktree is checked out. Pinning the root makes resolution deterministic; ignoring `.worktrees/` keeps ESLint from descending into sibling checkouts.

Verified: `npm run lint` passes from a worktree under `.worktrees/` with several sibling worktrees present.