### PR TITLE
Footer redesign: stacked left

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,26 +16,19 @@ const sourceUrl = sourcePath ? `${SITE.viewSource.url}${sourcePath}` : undefined
 
 <footer class:list={["w-full", { "mt-auto": !noMarginTop }]}>
   <Hr noPadding />
-  <div
-    class="flex flex-col items-center justify-between py-6 sm:flex-row-reverse sm:py-4"
-  >
-    <Socials centered />
-    <div class="my-2 flex flex-col items-center whitespace-nowrap sm:flex-row">
-      <span>Copyright &#169; {currentYear}</span>
-      <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
-      <span>All rights reserved.</span>
+  <div class="flex flex-col items-start gap-2 py-4 text-left">
+    <Socials />
+    <div class="flex flex-wrap items-center gap-x-3 text-xs text-foreground/60">
+      <span>&#169; {currentYear} Ben Drucker</span>
       {sourceUrl && (
-        <>
-          <span class="hidden sm:inline">&nbsp;|&nbsp;</span>
-          <a
-            href={sourceUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-accent"
-          >
-            {SITE.viewSource.text}
-          </a>
-        </>
+        <a
+          href={sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-accent"
+        >
+          {SITE.viewSource.text}
+        </a>
       )}
     </div>
   </div>

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -9,15 +9,20 @@ export interface Props {
 const { centered = false } = Astro.props;
 ---
 
-<div class:list={["flex-wrap justify-center gap-1", { flex: centered }]}>
+<div
+  class:list={[
+    "flex flex-wrap gap-0.5",
+    centered ? "justify-center" : "justify-start",
+  ]}
+>
   {
     SOCIALS.map(social => (
       <LinkButton
         href={social.href}
-        class="p-2 hover:rotate-6 sm:p-1"
+        class="p-1 text-foreground/60 hover:rotate-6"
         title={social.linkTitle}
       >
-        <social.icon class="inline-block size-6 scale-125 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent sm:scale-110" />
+        <social.icon class="inline-block size-5 fill-transparent stroke-current stroke-2 group-hover:fill-transparent" />
         <span class="sr-only">{social.linkTitle}</span>
       </LinkButton>
     ))


### PR DESCRIPTION
Redesigns the footer as a quiet, left-aligned stack: social icons row on top, small dimmed copyright below, both flush-left on all screen sizes.

- Icons shrink to `size-5` and dim to `text-foreground/60` (removed `scale-125`/`opacity-90`), tightened into a compact left-aligned cluster.
- Copyright becomes plain `text-xs text-foreground/60` "© {year} Ben Drucker" with an inline view-source link (no pipe separators), lighter `py-4` padding.
- `Socials` gains left-alignment while keeping the `centered` prop working; icons and text share the same `/60` weight.