### PR TITLE
feat: animate the mobile nav menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -15,8 +15,8 @@ const currentPath =
   pathname.endsWith("/") && pathname !== "/" ? pathname.slice(0, -1) : pathname;
 
 const isActive = (path: string) => {
-  const currentPathArray = currentPath.split("/").filter(p => p.trim());
-  const pathArray = path.split("/").filter(p => p.trim());
+  const currentPathArray = currentPath.split("/").filter((p) => p.trim());
+  const pathArray = path.split("/").filter((p) => p.trim());
 
   return currentPath === path || currentPathArray[0] === pathArray[0];
 };
@@ -58,56 +58,63 @@ const isActive = (path: string) => {
           <IconX id="close-icon" class="hidden" />
           <IconMenuDeep id="menu-icon" />
         </button>
-        <ul
-          id="menu-items"
-          class:list={[
-            "mt-4 grid w-44 grid-cols-2 place-content-center gap-2",
-            "[&>li>a]:block [&>li>a]:px-4 [&>li>a]:py-3 [&>li>a]:text-center [&>li>a]:font-medium [&>li>a]:hover:text-accent sm:[&>li>a]:px-2 sm:[&>li>a]:py-1",
-            "sm:mt-0 sm:flex sm:w-auto sm:gap-x-5 sm:gap-y-0",
-          ]}
-        >
-          <li class="col-span-2">
-            <a href="/about" class:list={{ "active-nav": isActive("/about") }}>
-              About
-            </a>
-          </li>
-          {
-            SITE.showArchives && (
+        <div id="menu-items" class="sm:contents">
+          <div class="sm:contents">
+            <ul
+              class:list={[
+                "grid w-44 grid-cols-2 place-content-center gap-2 pt-4",
+                "[&>li>a]:block [&>li>a]:px-4 [&>li>a]:py-3 [&>li>a]:text-center [&>li>a]:font-medium [&>li>a]:hover:text-accent sm:[&>li>a]:px-2 sm:[&>li>a]:py-1",
+                "sm:flex sm:w-auto sm:gap-x-5 sm:gap-y-0 sm:pt-0",
+              ]}
+            >
               <li class="col-span-2">
-                <LinkButton
-                  href="/archives"
-                  class:list={[
-                    "focus-outline flex justify-center p-3 sm:p-1",
-                    {
-                      "active-nav [&>svg]:stroke-accent": isActive("/archives"),
-                    },
-                  ]}
-                  ariaLabel="archives"
-                  title="Archives"
+                <a
+                  href="/about"
+                  class:list={{ "active-nav": isActive("/about") }}
                 >
-                  <IconArchive class="hidden sm:inline-block" />
-                  <span class="sm:sr-only">Archives</span>
-                </LinkButton>
+                  About
+                </a>
               </li>
-            )
-          }
-          {
-            SITE.lightAndDarkMode && (
-              <li class="col-span-2 flex items-center justify-center">
-                <button
-                  id="theme-btn"
-                  class="focus-outline relative size-12 p-4 sm:size-8 hover:[&>svg]:stroke-accent"
-                  title="Toggles light & dark"
-                  aria-label="auto"
-                  aria-live="polite"
-                >
-                  <IconMoon class="absolute top-[50%] left-[50%] -translate-[50%] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-                  <IconSunHigh class="absolute top-[50%] left-[50%] -translate-[50%] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-                </button>
-              </li>
-            )
-          }
-        </ul>
+              {
+                SITE.showArchives && (
+                  <li class="col-span-2">
+                    <LinkButton
+                      href="/archives"
+                      class:list={[
+                        "focus-outline flex justify-center p-3 sm:p-1",
+                        {
+                          "active-nav [&>svg]:stroke-accent":
+                            isActive("/archives"),
+                        },
+                      ]}
+                      ariaLabel="archives"
+                      title="Archives"
+                    >
+                      <IconArchive class="hidden sm:inline-block" />
+                      <span class="sm:sr-only">Archives</span>
+                    </LinkButton>
+                  </li>
+                )
+              }
+              {
+                SITE.lightAndDarkMode && (
+                  <li class="col-span-2 flex items-center justify-center">
+                    <button
+                      id="theme-btn"
+                      class="focus-outline relative size-12 p-4 sm:size-8 hover:[&>svg]:stroke-accent"
+                      title="Toggles light & dark"
+                      aria-label="auto"
+                      aria-live="polite"
+                    >
+                      <IconMoon class="absolute top-[50%] left-[50%] -translate-[50%] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+                      <IconSunHigh class="absolute top-[50%] left-[50%] -translate-[50%] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+                    </button>
+                  </li>
+                )
+              }
+            </ul>
+          </div>
+        </div>
       </nav>
     </div>
   </div>
@@ -117,30 +124,33 @@ const isActive = (path: string) => {
 <style>
   @media (width < 640px) {
     #menu-items {
-      display: none;
-      opacity: 0;
-      transform: translateY(-0.25rem);
-      transition:
-        opacity 200ms ease-out,
-        transform 200ms ease-out,
-        display 200ms allow-discrete;
+      display: grid;
+      grid-template-rows: 0fr;
+      transition: grid-template-rows 200ms ease-out;
     }
 
     #menu-btn[aria-expanded="true"] ~ #menu-items {
-      display: grid;
-      opacity: 1;
-      transform: translateY(0);
+      grid-template-rows: 1fr;
     }
 
-    @starting-style {
-      #menu-btn[aria-expanded="true"] ~ #menu-items {
-        opacity: 0;
-        transform: translateY(-0.25rem);
-      }
+    #menu-items > div {
+      min-height: 0;
+      overflow: hidden;
+      opacity: 0;
+      visibility: hidden;
+      transition:
+        opacity 200ms ease-out,
+        visibility 200ms;
+    }
+
+    #menu-btn[aria-expanded="true"] ~ #menu-items > div {
+      opacity: 1;
+      visibility: visible;
     }
 
     @media (prefers-reduced-motion: reduce) {
-      #menu-items {
+      #menu-items,
+      #menu-items > div {
         transition: none;
       }
     }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -63,7 +63,6 @@ const isActive = (path: string) => {
           class:list={[
             "mt-4 grid w-44 grid-cols-2 place-content-center gap-2",
             "[&>li>a]:block [&>li>a]:px-4 [&>li>a]:py-3 [&>li>a]:text-center [&>li>a]:font-medium [&>li>a]:hover:text-accent sm:[&>li>a]:px-2 sm:[&>li>a]:py-1",
-            "hidden",
             "sm:mt-0 sm:flex sm:w-auto sm:gap-x-5 sm:gap-y-0",
           ]}
         >
@@ -115,14 +114,46 @@ const isActive = (path: string) => {
   <Hr />
 </header>
 
+<style>
+  @media (width < 640px) {
+    #menu-items {
+      display: none;
+      opacity: 0;
+      transform: translateY(-0.25rem);
+      transition:
+        opacity 200ms ease-out,
+        transform 200ms ease-out,
+        display 200ms allow-discrete;
+    }
+
+    #menu-btn[aria-expanded="true"] ~ #menu-items {
+      display: grid;
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    @starting-style {
+      #menu-btn[aria-expanded="true"] ~ #menu-items {
+        opacity: 0;
+        transform: translateY(-0.25rem);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      #menu-items {
+        transition: none;
+      }
+    }
+  }
+</style>
+
 <script>
   function toggleNav() {
     const menuBtn = document.querySelector("#menu-btn");
-    const menuItems = document.querySelector("#menu-items");
     const menuIcon = document.querySelector("#menu-icon");
     const closeIcon = document.querySelector("#close-icon");
 
-    if (!menuBtn || !menuItems || !menuIcon || !closeIcon) return;
+    if (!menuBtn || !menuIcon || !closeIcon) return;
 
     menuBtn.addEventListener("click", () => {
       const openMenu = menuBtn.getAttribute("aria-expanded") === "true";
@@ -130,7 +161,6 @@ const isActive = (path: string) => {
       menuBtn.setAttribute("aria-expanded", openMenu ? "false" : "true");
       menuBtn.setAttribute("aria-label", openMenu ? "Open Menu" : "Close Menu");
 
-      menuItems.classList.toggle("hidden");
       menuIcon.classList.toggle("hidden");
       closeIcon.classList.toggle("hidden");
     });


### PR DESCRIPTION
Adds a subtle open/close animation to the mobile nav menu, which previously snapped in and out by toggling Tailwind's `hidden` class.

The menu's visibility is driven from CSS keyed on the button's `aria-expanded` state, via the general-sibling selector `#menu-btn[aria-expanded="true"] ~ #menu-items`. `toggleNav()` no longer touches `hidden`; it just flips `aria-expanded`/`aria-label` and swaps the menu/close icons.

Rather than fading a fixed-height list in place, the menu animates its **height** so the header's `<Hr />` and the page below slide down smoothly as it opens, instead of the rule jumping to its final position while the text fades in. This uses the `grid-template-rows: 0fr → 1fr` collapse technique: `#menu-items` is a one-row grid whose track animates open, with the list clipped inside an `overflow: hidden` child. The list fades in over the same 200ms (`opacity` + `visibility`, the latter keeping the links out of the tab order while closed). `grid-template-rows` animates across modern browsers (Chrome, Safari 16+, Firefox), unlike `height: auto` tricks that are Chromium-only.

The collapse is scoped to `@media (width < 640px)`. A second wrapper lets both levels become `display: contents` at `sm`, so the desktop inline `flex` layout is untouched. Motion is dropped under `prefers-reduced-motion: reduce`.

Verified in a browser repro that the closed state collapses to height 0 with the list hidden, and the open state expands to full content and pushes the Hr down. `astro check` + `astro build` pass, and the scoped rules compile correctly into the output CSS. The dev server couldn't be driven for a live capture here due to an unrelated pre-existing Cloudflare vite-runner error (`Missing field 'moduleType'`), so the open/close slide is worth a quick manual look under 640px before merge.
