### PR TITLE
feat: refresh about page with Phosphor line icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,8 @@
       },
       "devDependencies": {
         "@astrojs/check": "0.9.9",
+        "@iconify-json/tabler": "^1.2.35",
+        "@iconify/tailwind4": "^1.2.3",
         "@lhci/cli": "^0.15.1",
         "@sentry/astro": "^10.62.0",
         "@shikijs/transformers": "^4.3.0",
@@ -60,6 +62,20 @@
         "typescript-eslint": "^8.61.1",
         "vitest": "^4.1.9",
         "wrangler": "^4.103.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
@@ -1593,6 +1609,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@cyberalien/svg-utils": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@cyberalien/svg-utils/-/svg-utils-1.2.18.tgz",
+      "integrity": "sha512-avRdGj4MNoFyjehtaMhAggiceWmKRS5tB+P9YKZdcCATQsTYeiYifBjo0suyXOMIdadCcqxAZYniA305dpaMAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      }
+    },
     "node_modules/@date-fns/tz": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
@@ -2438,6 +2464,76 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify-json/tabler": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@iconify-json/tabler/-/tabler-1.2.35.tgz",
+      "integrity": "sha512-/sJMqHvh5ZWrEERVfDCT5NjVDeKJdhosFtKjJofAVl+P/3AzLiryOQw7WvrfDF25Xa5N/eoOQ15Y1jnhYXxBoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/tailwind4": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@iconify/tailwind4/-/tailwind4-1.2.3.tgz",
+      "integrity": "sha512-z8SKiMHRASJKF/IY//87MF88lcB7ulxh8vlhQXXLWsBkNtOh6ese9R41MyGpQeqXdRvQVt+/fX2glQtHFjQ+MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/tools": "^5.0.5",
+        "@iconify/types": "^2.0.0",
+        "@iconify/utils": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">= 4.0.0"
+      }
+    },
+    "node_modules/@iconify/tools": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@iconify/tools/-/tools-5.0.12.tgz",
+      "integrity": "sha512-aFPwSFmFphUPVjNLUkgxgUPSPVgTEEjv0mE7NgvfoQBuE5TtsMrKa4HTY65cM5oXZ2a1xKQcW/RKhiOKEiAarw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cyberalien/svg-utils": "^1.2.15",
+        "@iconify/types": "^2.0.0",
+        "@iconify/utils": "^3.1.3",
+        "fflate": "^0.8.3",
+        "modern-tar": "^0.7.6",
+        "pathe": "^2.0.3",
+        "svgo": "^4.0.1"
+      }
+    },
+    "node_modules/@iconify/tools/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@img/colour": {
@@ -11016,6 +11112,17 @@
         "module-details-from-path": "^1.0.4"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -13181,6 +13288,16 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "0.9.9",
-        "@iconify-json/tabler": "^1.2.35",
+        "@iconify-json/ph": "^1.2.2",
         "@iconify/tailwind4": "^1.2.3",
         "@lhci/cli": "^0.15.1",
         "@sentry/astro": "^10.62.0",
@@ -2466,10 +2466,10 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@iconify-json/tabler": {
-      "version": "1.2.35",
-      "resolved": "https://registry.npmjs.org/@iconify-json/tabler/-/tabler-1.2.35.tgz",
-      "integrity": "sha512-/sJMqHvh5ZWrEERVfDCT5NjVDeKJdhosFtKjJofAVl+P/3AzLiryOQw7WvrfDF25Xa5N/eoOQ15Y1jnhYXxBoQ==",
+    "node_modules/@iconify-json/ph": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@iconify-json/ph/-/ph-1.2.2.tgz",
+      "integrity": "sha512-PgkEZNtqa8hBGjHXQa4pMwZa93hmfu8FUSjs/nv4oUU6yLsgv+gh9nu28Kqi8Fz9CCVu4hj1MZs9/60J57IzFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
+    "@iconify-json/tabler": "^1.2.35",
+    "@iconify/tailwind4": "^1.2.3",
     "@lhci/cli": "^0.15.1",
     "@sentry/astro": "^10.62.0",
     "@shikijs/transformers": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
-    "@iconify-json/tabler": "^1.2.35",
+    "@iconify-json/ph": "^1.2.2",
     "@iconify/tailwind4": "^1.2.3",
     "@lhci/cli": "^0.15.1",
     "@sentry/astro": "^10.62.0",

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -3,22 +3,22 @@ layout: ../layouts/AboutLayout.astro
 title: "About"
 ---
 
-## 💻 Code
+## Code
 
 You can find my programming projects on [GitHub](https://github.com/bendrucker). I work on a variety of open source projects, mainly in Go and JavaScript. You can also find a [recent code activity index](/activity/code) on this site, which shows repositories where I am contributing and a summary of contributions by type.
 
-## 🚴 Cycling
+## Cycling
 
 Find my rides on [Strava](https://www.strava.com/athletes/5723594). I am a longtime member and current president of the [San Francisco Cycling Club](https://www.sfcyclingclub.org).
 
-## 💼 Work
+## Work
 
 Founding engineer at _Stealth_.
 
-## 📧 Contact
+## Contact
 
 The best way to reach me is via [email](mailto:bvdrucker@gmail.com). I'm not actively posting to any of my social profiles.
 
-## 🔧 Source Code
+## Source Code
 
 The source code for this website is available on GitHub ([`bendrucker/bendrucker.me`](https://github.com/bendrucker/bendrucker.me)), under the [MIT license](https://github.com/bendrucker/bendrucker.me/blob/master/LICENSE). Pull requests are welcome if you notice a typo!

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -1,0 +1,66 @@
+@layer components {
+  /* Assign each section its Tabler glyph by heading id. `:where()` keeps these
+     at the same specificity as the layout rules below, so the responsive
+     overrides win by source order rather than an id-specificity arms race. */
+  #about h2:where(#code)::before {
+    @apply icon-[tabler--code];
+  }
+  #about h2:where(#cycling)::before {
+    @apply icon-[tabler--bike];
+  }
+  #about h2:where(#work)::before {
+    @apply icon-[tabler--briefcase];
+  }
+  #about h2:where(#contact)::before {
+    @apply icon-[tabler--mail];
+  }
+  #about h2:where(#source-code)::before {
+    @apply icon-[tabler--git-fork];
+  }
+
+  #about h2 {
+    position: relative;
+    margin-top: 3.5rem;
+    border-top: 1px solid var(--color-border);
+    padding-top: 2rem;
+  }
+
+  #about h2:first-of-type {
+    margin-top: 2.5rem;
+  }
+
+  /* Mobile: the icon rides above the heading as a centered divider mark,
+     while the heading text stays left-aligned with the body copy. */
+  #about h2::before {
+    content: "";
+    display: block;
+    width: 1em;
+    height: 1em;
+    margin: 0 auto 0.85rem;
+    font-size: 1.6rem;
+    color: var(--color-accent);
+  }
+
+  /* Very wide viewports: the icon floats out into the left gutter, aligned to
+     the heading, and the divider treatment falls away. */
+  @media (min-width: 80rem) {
+    #about h2,
+    #about h2:first-of-type {
+      margin-top: 3rem;
+      border-top: none;
+      padding-top: 0;
+    }
+
+    #about h2:first-of-type {
+      margin-top: 1.5rem;
+    }
+
+    #about h2::before {
+      position: absolute;
+      top: 0.1em;
+      right: 100%;
+      margin: 0 2rem 0 0;
+      font-size: 1.75rem;
+    }
+  }
+}

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -2,65 +2,53 @@
   /* Assign each section its Tabler glyph by heading id. `:where()` keeps these
      at the same specificity as the layout rules below, so the responsive
      overrides win by source order rather than an id-specificity arms race. */
-  #about h2:where(#code)::before {
+  #about h2:where(#code)::after {
     @apply icon-[tabler--code];
   }
-  #about h2:where(#cycling)::before {
+  #about h2:where(#cycling)::after {
     @apply icon-[tabler--bike];
   }
-  #about h2:where(#work)::before {
+  #about h2:where(#work)::after {
     @apply icon-[tabler--briefcase];
   }
-  #about h2:where(#contact)::before {
+  #about h2:where(#contact)::after {
     @apply icon-[tabler--mail];
   }
-  #about h2:where(#source-code)::before {
+  #about h2:where(#source-code)::after {
     @apply icon-[tabler--git-fork];
   }
 
   #about h2 {
     position: relative;
-    margin-top: 3.5rem;
-    border-top: 1px solid var(--color-border);
-    padding-top: 2rem;
+    margin-top: 3rem;
   }
 
   #about h2:first-of-type {
-    margin-top: 2.5rem;
+    margin-top: 1.5rem;
   }
 
-  /* Mobile: the icon rides above the heading as a centered divider mark,
-     while the heading text stays left-aligned with the body copy. */
-  #about h2::before {
+  /* Default: a small, muted icon sits just to the right of the heading text. */
+  #about h2::after {
     content: "";
-    display: block;
+    display: inline-block;
     width: 1em;
     height: 1em;
-    margin: 0 auto 0.85rem;
-    font-size: 1.6rem;
-    color: var(--color-accent);
+    margin-left: 0.55em;
+    font-size: 1.1rem;
+    vertical-align: -0.1em;
+    color: color-mix(in oklab, var(--color-foreground) 35%, transparent);
   }
 
   /* Very wide viewports: the icon floats out into the left gutter, aligned to
-     the heading, and the divider treatment falls away. */
+     the heading. */
   @media (min-width: 80rem) {
-    #about h2,
-    #about h2:first-of-type {
-      margin-top: 3rem;
-      border-top: none;
-      padding-top: 0;
-    }
-
-    #about h2:first-of-type {
-      margin-top: 1.5rem;
-    }
-
-    #about h2::before {
+    #about h2::after {
       position: absolute;
-      top: 0.1em;
+      top: 0.2em;
       right: 100%;
-      margin: 0 2rem 0 0;
-      font-size: 1.75rem;
+      margin: 0 1.75rem 0 0;
+      font-size: 1.25rem;
+      vertical-align: baseline;
     }
   }
 }

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -1,21 +1,22 @@
 @layer components {
-  /* Assign each section its Tabler glyph by heading id. `:where()` keeps these
+  /* Assign each section its Phosphor glyph by heading id. `:where()` keeps these
      at the same specificity as the layout rules below, so the responsive
-     overrides win by source order rather than an id-specificity arms race. */
+     overrides win by source order rather than an id-specificity arms race.
+     Phosphor's `-light` weight gives a 1.5px stroke, lighter than Tabler's 2px. */
   #about h2:where(#code)::after {
-    @apply icon-[tabler--code];
+    @apply icon-[ph--code-light];
   }
   #about h2:where(#cycling)::after {
-    @apply icon-[tabler--bike];
+    @apply icon-[ph--bicycle-light];
   }
   #about h2:where(#work)::after {
-    @apply icon-[tabler--briefcase];
+    @apply icon-[ph--briefcase-light];
   }
   #about h2:where(#contact)::after {
-    @apply icon-[tabler--mail];
+    @apply icon-[ph--envelope-simple-light];
   }
   #about h2:where(#source-code)::after {
-    @apply icon-[tabler--git-fork];
+    @apply icon-[ph--git-fork-light];
   }
 
   #about h2 {
@@ -27,16 +28,17 @@
     margin-top: 1.5rem;
   }
 
-  /* Default: a small, muted icon sits just to the right of the heading text. */
+  /* Default: a light icon sits just to the right of the heading text. The thin
+     Phosphor stroke stays subtle even at a larger size. */
   #about h2::after {
     content: "";
     display: inline-block;
     width: 1em;
     height: 1em;
-    margin-left: 0.55em;
-    font-size: 1.1rem;
-    vertical-align: -0.1em;
-    color: color-mix(in oklab, var(--color-foreground) 35%, transparent);
+    margin-left: 0.75em;
+    font-size: 1.35rem;
+    vertical-align: -0.15em;
+    color: color-mix(in oklab, var(--color-foreground) 28%, transparent);
   }
 
   /* Very wide viewports: the icon floats out into the left gutter, aligned to
@@ -44,10 +46,10 @@
   @media (min-width: 80rem) {
     #about h2::after {
       position: absolute;
-      top: 0.2em;
+      top: 0.15em;
       right: 100%;
-      margin: 0 1.75rem 0 0;
-      font-size: 1.25rem;
+      margin: 0 1.6rem 0 0;
+      font-size: 1.5rem;
       vertical-align: baseline;
     }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 @import "./typography.css";
+@import "./about.css";
+
+@plugin "@iconify/tailwind4";
 
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 


### PR DESCRIPTION
Refreshes the About page by swapping the emoji section headings for Phosphor line icons, pulled from installable modules rather than vendored assets.

The icons come from the `@iconify-json/ph` module through the `@iconify/tailwind4` plugin, rendered as CSS masks keyed on each heading's auto-generated id. Nothing is vendored: no SVGs copied into the repo, no component wrapping. Phosphor's `light` weight gives a 1.5px stroke, lighter than Tabler's 2px, so the glyphs read as delicate line art.

`about.md` stays the single source. Its raw Markdown still backs the `text/markdown` content negotiation on `/about`, and the new layout is pure presentation in `src/styles/about.css` layered on top. No parallel HTML and Markdown authoring.

Layout has two states:

- Very wide viewports: the icon floats into the left gutter, aligned to the heading.
- Everything narrower: the icon sits inline just to the right of the heading text.

Icons use a muted gray derived from `--color-foreground` via `color-mix`, so they stay subtle and adapt to both light and dark themes. Verified both themes and both breakpoints against the built worker.
