### PR TITLE
fix: point View Source link at default branch via HEAD ref

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export const SITE = {
   showBackButton: true, // show back button in post detail
   viewSource: {
     text: "View Source",
-    url: "https://github.com/bendrucker/bendrucker.me/blob/master/",
+    url: "https://github.com/bendrucker/bendrucker.me/blob/HEAD/",
   },
   dynamicOgImage: false,
   dir: "ltr", // "rtl" | "auto"

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -21,4 +21,4 @@ The best way to reach me is via [email](mailto:bvdrucker@gmail.com). I'm not act
 
 ## 🔧 Source Code
 
-The source code for this website is available on GitHub ([`bendrucker/bendrucker.me`](https://github.com/bendrucker/bendrucker.me)), under the [MIT license](https://github.com/bendrucker/bendrucker.me/blob/master/LICENSE). Pull requests are welcome if you notice a typo!
+The source code for this website is available on GitHub ([`bendrucker/bendrucker.me`](https://github.com/bendrucker/bendrucker.me)), under the [MIT license](https://github.com/bendrucker/bendrucker.me/blob/HEAD/LICENSE). Pull requests are welcome if you notice a typo!


### PR DESCRIPTION
The footer "View Source" link and the about-page LICENSE link were hardcoded to `blob/master`, but the repo's default branch is now `main`, so both pointed at a stale ref.

Uses GitHub's `HEAD` ref instead of a branch name. In a `blob` URL, `HEAD` resolves to the repository's current default branch, so the links track whatever the default branch is at any given time, including after a future rename, without a build-time lookup.
