### PR TITLE
chore: remove unused Alpine.js integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # bendrucker.me
 
-Personal website/blog: Astro → Cloudflare Workers. TailwindCSS v4, Alpine.js, npm workspaces (`packages/*`, `workers/*`).
+Personal website/blog: Astro → Cloudflare Workers. TailwindCSS v4, Vue, npm workspaces (`packages/*`, `workers/*`).
 
 ## Structure
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig, envField } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
-import alpinejs from "@astrojs/alpinejs";
 import sentry from "@sentry/astro";
 import vue from "@astrojs/vue";
 import cloudflare from "@astrojs/cloudflare";
@@ -53,7 +52,6 @@ export default defineConfig({
     sitemap({
       filter: (page) => SITE.showArchives || !page.endsWith("/archives"),
     }),
-    alpinejs(),
     vue(),
     ...(isDev
       ? [

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "workers/*"
       ],
       "dependencies": {
-        "@astrojs/alpinejs": "1.0.0",
         "@astrojs/cloudflare": "14.1.1",
         "@astrojs/markdown-remark": "7.2.1",
         "@astrojs/rss": "4.0.19",
@@ -23,9 +22,7 @@
         "@date-fns/tz": "^1.5.0",
         "@sentry/cloudflare": "^10.62.0",
         "@tailwindcss/vite": "^4.3.1",
-        "@types/alpinejs": "^3.13.11",
         "@types/node": "^26.0.1",
-        "alpinejs": "^3.15.12",
         "astro": "7.0.6",
         "date-fns": "^4.4.0",
         "kysely": "^0.29.0",
@@ -128,16 +125,6 @@
         "@apm-js-collab/code-transformer": "^0.8.0",
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
-      }
-    },
-    "node_modules/@astrojs/alpinejs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/alpinejs/-/alpinejs-1.0.0.tgz",
-      "integrity": "sha512-xmLFD8MBunXCG39nS3dmINQfdhqlDNbHAYyw8n6jfLGL/AFeyYOtz6p1EtXX8NEbGLHk7mUOHoaC3j1WudUYoQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/alpinejs": "^3.0.0",
-        "alpinejs": "^3.0.0"
       }
     },
     "node_modules/@astrojs/check": {
@@ -6611,10 +6598,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/alpinejs": {
-      "version": "3.13.11",
-      "license": "MIT"
-    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -7516,13 +7499,6 @@
       "integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
       "license": "MIT"
     },
-    "node_modules/@vue/reactivity": {
-      "version": "3.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.1.5"
-      }
-    },
     "node_modules/@vue/runtime-core": {
       "version": "3.5.38",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
@@ -7592,10 +7568,6 @@
       "version": "3.5.38",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
       "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.1.5",
       "license": "MIT"
     },
     "node_modules/@vueuse/core": {
@@ -7761,15 +7733,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/alpinejs": {
-      "version": "3.15.12",
-      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
-      "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "~3.1.1"
-      }
     },
     "node_modules/am-i-vibing": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "generate:favicons": "tsx scripts/generate-favicons.ts"
   },
   "dependencies": {
-    "@astrojs/alpinejs": "1.0.0",
     "@astrojs/cloudflare": "14.1.1",
     "@astrojs/markdown-remark": "7.2.1",
     "@astrojs/rss": "4.0.19",
@@ -34,9 +33,7 @@
     "@date-fns/tz": "^1.5.0",
     "@sentry/cloudflare": "^10.62.0",
     "@tailwindcss/vite": "^4.3.1",
-    "@types/alpinejs": "^3.13.11",
     "@types/node": "^26.0.1",
-    "alpinejs": "^3.15.12",
     "astro": "7.0.6",
     "date-fns": "^4.4.0",
     "kysely": "^0.29.0",


### PR DESCRIPTION
Removes the Alpine.js integration, which was injecting the Alpine runtime into every page despite no Alpine code existing anywhere in the codebase. There are no `x-*` directives, no `Alpine.*` calls, and no entrypoint. All interactivity is vanilla JS (nav toggle, theme toggle, back-to-top) or Vue islands, so this is a pure removal with no behavior change.

Local verification covered a grep for Alpine references across `src/`, the config, and the lockfile, a full `astro build`, and an inspection of the build output for Alpine chunks. The `astro check` step of `npm run build` fails on strava worker `Env` type errors that pre-date this branch and reproduce identically on main. CI regenerates those types.
