### PR TITLE
feat: point home Programmer link at code activity

### DIFF
--- a/src/pages/activity/code.astro
+++ b/src/pages/activity/code.astro
@@ -35,8 +35,8 @@ try {
 }
 ---
 
-<Layout title={`Activity: Code | ${SITE.title}`} description="My public GitHub activity." ogImage="/activity/code/og.png" sourcePath="src/pages/activity/code.astro">
-  <Main pageTitle="Activity: Code" pageDesc="This page summarizes my GitHub activity by last contribution to each repository. It is an index of software projects I work on in public.">
+<Layout title={`Code | ${SITE.title}`} description="My public GitHub activity." ogImage="/activity/code/og.png" sourcePath="src/pages/activity/code.astro">
+  <Main pageTitle="Code" pageDesc="This page summarizes my GitHub activity by last contribution to each repository. It is an index of software projects I work on in public.">
     <section>
       <ActivityTimeline
         client:load

--- a/src/pages/activity/code/[year].astro
+++ b/src/pages/activity/code/[year].astro
@@ -53,7 +53,7 @@ try {
   logger.error({ error, year }, "Failed to load year activity data");
 }
 
-const title = `GitHub Activity: ${year} | ${SITE.title}`;
+const title = `Code: ${year} | ${SITE.title}`;
 const description = `${initialTotal} repositories ${SITE.author} last contributed to in ${year}.`;
 ---
 
@@ -64,7 +64,7 @@ const description = `${initialTotal} repositories ${SITE.author} last contribute
   sourcePath="src/pages/activity/code/[year].astro"
 >
   <Main
-    pageTitle={`Activity: Code (${year})`}
+    pageTitle={`Code (${year})`}
     pageDesc={`Repositories last contributed to in ${year}.`}
   >
     <section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,7 +21,7 @@ const featuredPosts = sortedPosts.filter(({ data }) => data.featured);
         class="w-32 h-32 rounded-lg mx-auto mb-6"
       />
       <p>
-        <LinkButton href="https://github.com/bendrucker" class="underline decoration-dashed underline-offset-4">Programmer</LinkButton>, <LinkButton href="https://www.strava.com/athletes/5723594" class="underline decoration-dashed underline-offset-4">cyclist</LinkButton>, and photographer, living in San Francisco.
+        <LinkButton href="/activity/code" class="underline decoration-dashed underline-offset-4">Programmer</LinkButton>, <LinkButton href="https://www.strava.com/athletes/5723594" class="underline decoration-dashed underline-offset-4">cyclist</LinkButton>, and photographer, living in San Francisco.
       </p>
     </section>
 


### PR DESCRIPTION
The home hero sent "Programmer" off to GitHub at exactly the moment a visitor was asking what kind of programmer I am. `/activity/code` already answers that better than a profile page does, but nothing pointed at it. Outside the activity feature itself, the only way in was a mid-paragraph link on `/about`. "cyclist" still goes to Strava, so the hero is no longer uniformly outbound. That asymmetry is deliberate. The code index is mine and the Strava profile isn't.

Dropping the "Activity:" prefix while here. The breadcrumb renders `Home » Activity » Code` directly above the `h1`, so "Activity: Code" just repeated the crumb. The year page was also disagreeing with itself, carrying an `h1` of "Activity: Code (2025)" under a `<title>` of "GitHub Activity: 2025". Both now read Code.

That leaves two other names for this page untouched. The OG image still says "GitHub Activity" and the markdown response still says "# Code Activity". Both are out of scope here, and collapsing the markdown headings would churn `_markdown.test.ts` for no reader-visible gain. Worth a follow-up if the inconsistency bothers you.

I couldn't drive the pages locally to confirm the rendering. The dev server won't boot in a worktree, and `astro build` fails resolving workspace packages against the root `node_modules`. `astro check` is clean on all three files, and the 9 `Env` binding errors it reports in `workers/strava/main.ts` are the usual stale generated types, unrelated and pre-existing on `main`. CI renders it properly.
