### PR TITLE
feat: open external footer social links in a new tab

### DIFF
--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -6,6 +6,7 @@ export interface Props {
   ariaLabel?: string;
   title?: string;
   disabled?: boolean;
+  newTab?: boolean;
 }
 
 const {
@@ -15,6 +16,7 @@ const {
   ariaLabel,
   title,
   disabled = false,
+  newTab = false,
 } = Astro.props;
 ---
 
@@ -35,6 +37,8 @@ const {
       class:list={["group inline-block hover:text-accent", className]}
       aria-label={ariaLabel}
       title={title}
+      target={newTab ? "_blank" : undefined}
+      rel={newTab ? "noopener noreferrer" : undefined}
     >
       <slot />
     </a>

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -16,6 +16,7 @@ const { centered = false } = Astro.props;
         href={social.href}
         class="p-1 text-foreground/50 hover:rotate-6"
         title={social.linkTitle}
+        newTab={social.href.startsWith("http")}
       >
         <social.icon class="inline-block size-4 fill-transparent stroke-current stroke-2 group-hover:fill-transparent" />
         <span class="sr-only">{social.linkTitle}</span>


### PR DESCRIPTION
Opens the footer's GitHub, LinkedIn, and Strava links in a new tab, so clicking an icon no longer navigates readers off the site. This matches the View Source link sitting next to them, which already opens in a new tab.

`LinkButton` gains an optional `newTab` prop rather than hardcoding the attributes, since it also backs share links and pagination, which should keep navigating in place. `Socials` derives the value from the href instead of adding a field to each `SOCIALS` entry, so a new social gets the right behavior without extra bookkeeping.

Two of the five entries are deliberately excluded. The `mailto:` link hands off to a mail client and would strand an empty tab behind it, and the RSS feed is same-site.

Verified against the built HTML: the three external anchors carry `target="_blank" rel="noopener noreferrer"` and the mail and RSS anchors carry neither.
