### PR TITLE
fix: stop body clipping its background to the viewport

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -162,12 +162,3 @@ const structuredData = pubDatetime
     <Footer sourcePath={sourcePath} />
   </body>
 </html>
-
-<style>
-  html,
-  body {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,6 +8,7 @@
 
 :root,
 html[data-theme="light"] {
+  color-scheme: light;
   --background: #fdfdfd;
   --foreground: #282728;
   --accent: #006cac;
@@ -16,6 +17,7 @@ html[data-theme="light"] {
 }
 
 html[data-theme="dark"] {
+  color-scheme: dark;
   --background: #212737;
   --foreground: #eaedf3;
   --accent: #ff6b01;


### PR DESCRIPTION
On iPad Safari with the [Noir](https://getnoir.app/) extension, `/about` rendered with two
backgrounds: the site's `#212737` down to a hard horizontal line, then near-black below it.
The seam fell mid-content rather than at the end of the document.

`Layout.astro` carried an unlayered `html, body { height: 100% }`. That pins `body`'s box to
the viewport height. Content taller than the viewport overflows it, and `body` paints
`bg-background` over only the first viewport's worth of page. Normally that is invisible.
`html` has no background of its own. The UA therefore propagates `body`'s background onto the
canvas and paints it over the whole scrollable area, and the site looked right by accident. Noir injects
a background onto `html`, which halts propagation, and everything past the first viewport
falls through to Noir's black. This is our bug. Noir only exposed it.

The rest of the block was already dead weight. Tailwind preflight zeroes the margin via
`*{margin:0}`, and `html`/`body` are block-level so they already fill their containing block.
`body` has `min-h-svh`, which is the behavior the `height` wanted: fill the viewport when
content is short, grow with it when it's long. Nothing depends on the html/body height chain.
The only `h-full` usages sit inside an explicit `h-6` parent (`LanguageBar`) or resolve against
a positioned ancestor (`TimelineRail`).

The `color-scheme` lines are hardening against the same class of bug. Deleting the `height`
is what closes the seam. Theme is driven by `data-theme` from `localStorage`, independent of
`prefers-color-scheme`, so nothing told the browser this page had its own dark treatment.
`color-scheme` is the standard signal that extensions like Noir and Safari read to decide
whether to leave a page alone. It also fixes UA scrollbars, form controls, and the iOS
rubber-band overscroll region.

## Testing

Reproduced against a local build of `/about` at 1000x700 with `data-theme="dark"`, injecting
`html{background-color:#000 !important}` to stand in for Noir:

| | before | after |
| --- | --- | --- |
| `body` painted box | 523px | 1119px |
| content bottom | 1119px | 1119px |
| unpainted overflow | **596px** | **0px** |

The 596px gap matched the reported iPad screenshot: same split, same boundary, same sections.
Scrolled to the footer with the black `html` still forced and the background is uniform.
`getComputedStyle(document.documentElement).colorScheme` tracks the toggle in both directions.

Not yet checked on the real iPad + Noir setup that reported it, which is the only place Noir's
actual injected CSS is in play.
