### PR TITLE
fix: untrack the committed node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ public/
 .astro/
 
 # dependencies
-node_modules/
+node_modules
 
 # logs
 npm-debug.log*

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/ben/src/bendrucker/bendrucker.me/node_modules


### PR DESCRIPTION
`node_modules` is tracked in this repo. It was committed in 4fdd85b as a symlink (mode `120000`) whose target is the absolute path `/Users/ben/src/bendrucker/bendrucker.me/node_modules`, so it is both machine-specific and meaningless to anyone else who clones this.

The ignore rule was `node_modules/` with a trailing slash, which matches only a directory. The committed entry is a file, so the rule never covered it, and `.gitignore` does not apply to already-tracked paths in any case. Dropping the slash covers both forms and stops `git add .` from recommitting it, which is how it got in.

This has stayed invisible because the main checkout carries a skip-worktree bit on the entry, which suppresses the discrepancy and hides the path from `git status`. Worktrees do not inherit that bit. Each one checks the symlink out, an install replaces it with a real directory, and git then sees a permanent deletion:

```
main:      S node_modules     # skip-worktree, suppressed
worktree:  H node_modules     # sees the symlink replaced by a directory
```

Every worktree in this repo is therefore dirty forever with `D node_modules`. That is not cosmetic: a dirty worktree cannot be removed without a force flag, so removal fails and the agent session that owns the worktree strands permanently after its PR merges. Every worktree present in the repo when I found this was affected.

Untracking the path leaves the on-disk symlink alone, so nothing about local builds changes.
