### PR TITLE
feat: add .md URLs, /llms.txt, and markdown discovery links

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import { PUBLIC_GOOGLE_SITE_VERIFICATION } from "astro:env/client";
 import { SITE } from "@/config";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
+import { representationFor } from "@/representations";
 import "@/styles/global.css";
 
 export interface Props {
@@ -33,6 +34,10 @@ const {
 } = Astro.props;
 
 const socialImageURL = new URL(ogImage, Astro.url);
+
+const markdownURL = representationFor(Astro.routePattern)
+  ? new URL(`${Astro.url.pathname.replace(/\/$/, "")}.md`, Astro.site)
+  : null;
 
 const structuredData = pubDatetime
   ? {
@@ -126,6 +131,13 @@ const structuredData = pubDatetime
       title={SITE.title}
       href={new URL("rss.xml", Astro.site)}
     />
+
+    <!-- Point agents at the markdown representation of this page -->
+    {
+      markdownURL && (
+        <link rel="alternate" type="text/markdown" href={`${markdownURL}`} />
+      )
+    }
 
     <meta
       name="theme-color"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import type { MiddlewareHandler } from "astro";
 import { sequence } from "astro:middleware";
 import { cachePolicy } from "./middleware/cache";
 import { negotiate, PRODUCES } from "./middleware/negotiate";
-import { representationFor } from "./representations";
+import { MARKDOWN_CONTENT_TYPE, representationFor } from "./representations";
 
 const cache: MiddlewareHandler = async (context, next) => {
   const response = await next();
@@ -33,7 +33,7 @@ const markdown: MiddlewareHandler = async (context, next) => {
     if (md !== null) {
       return new Response(request.method === "HEAD" ? null : md, {
         headers: {
-          "Content-Type": "text/markdown; charset=utf-8",
+          "Content-Type": MARKDOWN_CONTENT_TYPE,
           Vary: "Accept",
         },
       });

--- a/src/pages/about.md.ts
+++ b/src/pages/about.md.ts
@@ -1,0 +1,3 @@
+import { about, markdownEndpoint } from "@/representations";
+
+export const GET = markdownEndpoint(about);

--- a/src/pages/activity/code.md.ts
+++ b/src/pages/activity/code.md.ts
@@ -1,0 +1,3 @@
+import { activity, markdownEndpoint } from "@/representations";
+
+export const GET = markdownEndpoint(activity);

--- a/src/pages/activity/code/[year].md.ts
+++ b/src/pages/activity/code/[year].md.ts
@@ -1,0 +1,3 @@
+import { activityYear, markdownEndpoint } from "@/representations";
+
+export const GET = markdownEndpoint(activityYear);

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+import { SITE } from "@/config";
+import { listRepresentations } from "@/representations";
+
+export const GET: APIRoute = async ({ site }) => {
+  const sections = await listRepresentations();
+
+  const lines = [`# ${SITE.title}`, "", `> ${SITE.desc}`];
+
+  for (const section of sections) {
+    lines.push("", `## ${section.title}`, "");
+    for (const { path, title, description } of section.entries) {
+      const url = new URL(`${path}.md`, site);
+      lines.push(
+        description
+          ? `- [${title}](${url}): ${description}`
+          : `- [${title}](${url})`,
+      );
+    }
+  }
+
+  lines.push("");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};

--- a/src/pages/posts/[...slug].md.ts
+++ b/src/pages/posts/[...slug].md.ts
@@ -1,0 +1,3 @@
+import { markdownEndpoint, posts } from "@/representations";
+
+export const GET = markdownEndpoint(posts);

--- a/src/representations/about.ts
+++ b/src/representations/about.ts
@@ -1,7 +1,18 @@
+import { SITE } from "@/config";
 import type { Representation } from "./types";
 import aboutMd from "../pages/about.md?raw";
 
+const FRONTMATTER = /^---\r?\n[\s\S]*?\r?\n---\r?\n/;
+
 export const about: Representation = {
   route: "/about",
-  render: async () => aboutMd,
+  section: "Pages",
+  render: async () => aboutMd.replace(FRONTMATTER, "").trimStart(),
+  list: async () => [
+    {
+      path: "/about",
+      title: "About",
+      description: `About ${SITE.author}.`,
+    },
+  ],
 };

--- a/src/representations/activity.test.ts
+++ b/src/representations/activity.test.ts
@@ -51,6 +51,16 @@ describe("activity", () => {
     expect(md).toContain("## bendrucker/cool-lib");
     expect(md).toContain("## bendrucker/newer-lib");
   });
+
+  it("lists itself once", async () => {
+    expect(await activity.list()).toEqual([
+      {
+        path: "/activity/code",
+        title: "Code Activity",
+        description: "Public GitHub activity, indexed by repository.",
+      },
+    ]);
+  });
 });
 
 describe("activityYear", () => {
@@ -68,5 +78,20 @@ describe("activityYear", () => {
 
   it("falls through to HTML for a non-numeric year", async () => {
     expect(await activityYear.render(context({ year: "og.png" }))).toBeNull();
+  });
+
+  it("lists one entry per year with activity", async () => {
+    expect(await activityYear.list()).toEqual([
+      {
+        path: "/activity/code/2025",
+        title: "Code Activity: 2025",
+        description: "1 repository last contributed to in 2025.",
+      },
+      {
+        path: "/activity/code/2024",
+        title: "Code Activity: 2024",
+        description: "1 repository last contributed to in 2024.",
+      },
+    ]);
   });
 });

--- a/src/representations/activity.ts
+++ b/src/representations/activity.ts
@@ -1,25 +1,54 @@
 import { getDb } from "@/db";
 import { formatReposMarkdown } from "@/pages/activity/code/_markdown";
-import { queryRepos } from "@/pages/activity/code/_query";
+import {
+  queryRepos,
+  queryYearsByLastActivity,
+} from "@/pages/activity/code/_query";
 import type { Representation } from "./types";
 
 export const activity: Representation = {
   route: "/activity/code",
+  section: "Activity",
+
   async render() {
     const { repos, total } = await queryRepos(await getDb(), {});
     return formatReposMarkdown(repos, total);
   },
+
+  list: async () => [
+    {
+      path: "/activity/code",
+      title: "Code Activity",
+      description: "Public GitHub activity, indexed by repository.",
+    },
+  ],
 };
 
 export const activityYear: Representation = {
   route: "/activity/code/[year]",
+  section: "Activity",
+
   async render({ params }) {
     const year = Number(params.year);
     if (!Number.isInteger(year)) return null;
 
-    const { repos, total } = await queryRepos(await getDb(), { year });
+    // `all` matches the HTML page, which lists every repository for the year
+    // rather than the first page of them.
+    const { repos, total } = await queryRepos(await getDb(), {
+      year,
+      all: true,
+    });
     if (total === 0) return null;
 
     return formatReposMarkdown(repos, total, { year });
+  },
+
+  async list() {
+    const { years } = await queryYearsByLastActivity(await getDb());
+    return years.map(({ year, count }) => ({
+      path: `/activity/code/${year}`,
+      title: `Code Activity: ${year}`,
+      description: `${count} ${count === 1 ? "repository" : "repositories"} last contributed to in ${year}.`,
+    }));
   },
 };

--- a/src/representations/endpoint.ts
+++ b/src/representations/endpoint.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from "astro";
+import type { Representation } from "./types";
+
+export const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
+
+/** Serves a representation at its `.md` sibling route. */
+export function markdownEndpoint(representation: Representation): APIRoute {
+  return async (context) => {
+    const md = await representation.render(context);
+    if (md === null) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    return new Response(context.request.method === "HEAD" ? null : md, {
+      headers: { "Content-Type": MARKDOWN_CONTENT_TYPE },
+    });
+  };
+}

--- a/src/representations/index.ts
+++ b/src/representations/index.ts
@@ -1,9 +1,11 @@
 import { about } from "./about";
 import { activity, activityYear } from "./activity";
 import { posts } from "./posts";
-import type { Representation } from "./types";
+import type { Representation, RepresentationEntry } from "./types";
 
-export type { Representation } from "./types";
+export type { Representation, RepresentationEntry } from "./types";
+export { markdownEndpoint, MARKDOWN_CONTENT_TYPE } from "./endpoint";
+export { about, activity, activityYear, posts };
 
 const REPRESENTATIONS: readonly Representation[] = [
   about,
@@ -23,4 +25,28 @@ export function representationFor(
   routePattern: string,
 ): Representation | undefined {
   return byRoute.get(routePattern);
+}
+
+export interface RepresentationSection {
+  title: string;
+  entries: RepresentationEntry[];
+}
+
+/** Every markdown document on the site, grouped for `/llms.txt`. */
+export async function listRepresentations(): Promise<RepresentationSection[]> {
+  const sections: RepresentationSection[] = [];
+
+  for (const representation of REPRESENTATIONS) {
+    const entries = await representation.list();
+    if (entries.length === 0) continue;
+
+    const section = sections.find((s) => s.title === representation.section);
+    if (section) {
+      section.entries.push(...entries);
+    } else {
+      sections.push({ title: representation.section, entries });
+    }
+  }
+
+  return sections;
 }

--- a/src/representations/posts.ts
+++ b/src/representations/posts.ts
@@ -1,10 +1,12 @@
 import { getCollection } from "astro:content";
 import { getPath } from "@/blog/path";
-import { postFilter } from "@/blog/posts";
+import { getSortedPosts, postFilter } from "@/blog/posts";
 import type { Representation } from "./types";
 
 export const posts: Representation = {
   route: "/posts/[...slug]",
+  section: "Posts",
+
   async render({ params }) {
     const slug = params.slug?.replace(/\/$/, "");
     if (!slug) return null;
@@ -14,5 +16,14 @@ export const posts: Representation = {
       (post) => getPath(post.id, post.filePath) === `/posts/${slug}`,
     );
     return entry?.body ?? null;
+  },
+
+  async list() {
+    const entries = await getCollection("blog");
+    return getSortedPosts(entries).map((post) => ({
+      path: getPath(post.id, post.filePath),
+      title: post.data.title,
+      description: post.data.description,
+    }));
   },
 };

--- a/src/representations/types.ts
+++ b/src/representations/types.ts
@@ -1,12 +1,24 @@
 import type { APIContext } from "astro";
 
+/** One markdown document, as advertised in `/llms.txt`. */
+export interface RepresentationEntry {
+  /** Page path without the `.md` suffix, e.g. `/posts/going-all-in`. */
+  path: string;
+  title: string;
+  description?: string;
+}
+
 /**
  * A markdown representation of an HTML route, served to clients that ask for
- * `text/markdown`.
+ * `text/markdown` and at the route's `.md` sibling.
  */
 export interface Representation {
   /** Astro route pattern, as reported by `APIContext.routePattern`. */
   route: string;
+  /** Heading this representation's entries are listed under in `/llms.txt`. */
+  section: string;
   /** Markdown for this request, or null when this request has none. */
   render(context: APIContext): Promise<string | null>;
+  /** Every document this representation can serve. */
+  list(): Promise<RepresentationEntry[]>;
 }


### PR DESCRIPTION
> Stacked on #548. Review that first. This PR's diff is against `astro-7-agent-surface`.

## Problem

The site already served markdown to agents via content negotiation, but nothing advertised it and there was no URL to link to. An agent had to guess that sending `Accept: text/markdown` would do something.

## Approach

Build the discovery layer on the representation registry from #548 rather than beside it.

**Enumeration.** `Representation` gains `list(): Promise<RepresentationEntry[]>` and a `section` label, so `/llms.txt` is generated *from the registry* instead of rebuilding the post list. Adding a surface is still one file.

**`.md` siblings are real routes, not middleware rewrites.** Astro strips the last extension when deriving a route, so `src/pages/posts/[...slug].md.ts` serves `/posts/[...slug].md`. Route priority puts it ahead of `/posts/[...slug]` because `priority.js` sorts an all-dynamic segment below one mixing a spread with static text. That was verified at runtime, not just read. Each endpoint is one line over a shared `markdownEndpoint` factory, and `render` is reused untouched since the `.md` patterns capture the same params.

**`/llms.txt` is server-rendered, not prerendered.** The activity years come from D1, which is unreachable at build time. It needs a `routeRules` entry in the follow-up caching PR.

**Discovery from the page itself.** `Layout.astro` emits `<link rel="alternate" type="text/markdown">` next to the existing RSS link, gated on `representationFor(Astro.routePattern)` so it only appears where a representation exists.

## Two agent-facing bugs fixed

Both pre-existing, both only ever affected markdown output:

- `/about` shipped its YAML frontmatter (`layout: ../layouts/AboutLayout.astro`, `title:`) to agents.
- `activityYear` markdown was paginated to 20 repositories while the HTML page listed the whole year. It now passes `all` to match.

## Verification

Against `astro build` + `wrangler dev` with migrations applied to local D1:

- **All 25 links in `/llms.txt` return 200 `text/markdown`** (scripted check, not spot-checked)
- `/posts/going-all-in.md` returns markdown, confirming the `.md` endpoint beats the page route
- `/about.md` has its frontmatter stripped
- `/activity/code.md` and `/activity/code/2024.md` return 200 markdown. `/activity/code/1999.md` returns 404
- The `/llms.txt` Activity section lists years read from D1 at request time
- `rel="alternate"` is present on `/about` and posts, absent on `/archives`
- Negotiation from #548 is unregressed: `Accept: text/markdown` yields markdown, `text/html, text/markdown;q=0.1` yields HTML

`vitest run`: 84 pass, including new coverage of both `list()` implementations. `astro check` and `eslint` clean.

## Note

`/llms.txt` links use absolute `https://` URLs from `Astro.site`. The `rel="alternate"` href does too. It initially derived from `Astro.url` and emitted `http://`, inconsistent with the RSS link right above it.