### PR TITLE
refactor: declare deploy-scoped cache policy in astro.config

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -20,6 +20,8 @@ import { join } from "node:path";
 
 const isDev = process.env.NODE_ENV === "development";
 
+const DEPLOY_SCOPED_CACHE = { maxAge: 3600, swr: 86400 };
+
 function copyStaticFiles(src: string, dest: string) {
   try {
     mkdirSync(dest, { recursive: true });
@@ -50,6 +52,19 @@ export default defineConfig({
   }),
   cache: {
     provider: cacheCloudflare(),
+  },
+  // On-demand routes that only change on deploy. `/activity` is absent because
+  // its max-age is aligned to the hourly GitHub sync and computed per request
+  // in src/middleware.ts. Prerendered routes are not cached at runtime.
+  routeRules: {
+    "/": DEPLOY_SCOPED_CACHE,
+    "/404": DEPLOY_SCOPED_CACHE,
+    "/about": DEPLOY_SCOPED_CACHE,
+    "/about.md": DEPLOY_SCOPED_CACHE,
+    "/posts/[...slug]": DEPLOY_SCOPED_CACHE,
+    "/posts/[...slug].md": DEPLOY_SCOPED_CACHE,
+    "/og.png": DEPLOY_SCOPED_CACHE,
+    "/llms.txt": DEPLOY_SCOPED_CACHE,
   },
   integrations: [
     sitemap({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { MiddlewareHandler } from "astro";
 import { sequence } from "astro:middleware";
-import { cachePolicy } from "./middleware/cache";
+import { activityCachePolicy, isActivityPath } from "./middleware/cache";
 import { negotiate, PRODUCES } from "./middleware/negotiate";
 import { MARKDOWN_CONTENT_TYPE, representationFor } from "./representations";
 
@@ -9,10 +9,19 @@ const cache: MiddlewareHandler = async (context, next) => {
   const { method } = context.request;
   if (method !== "GET" && method !== "HEAD") return response;
   if (context.isPrerendered) return response;
-  if (response.status !== 200) return response;
-  if (response.headers.has("Cache-Control")) return response;
 
-  context.cache.set(cachePolicy(context.url.pathname, new Date()));
+  // `routeRules` seeds a policy when the cache is created, before the response
+  // exists, and applies it with no regard for the status or an existing
+  // `Cache-Control`. Opt back out for responses that must not be cached.
+  if (response.status !== 200 || response.headers.has("Cache-Control")) {
+    context.cache.set(false);
+    return response;
+  }
+
+  if (isActivityPath(context.url.pathname)) {
+    context.cache.set(activityCachePolicy(new Date()));
+  }
+
   return response;
 };
 

--- a/src/middleware/cache.test.ts
+++ b/src/middleware/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { activityMaxAge, cachePolicy, DEFAULT_CACHE_POLICY } from "./cache";
+import { activityCachePolicy, activityMaxAge, isActivityPath } from "./cache";
 
 describe("activityMaxAge", () => {
   it("expires at five past the next hour mid-hour", () => {
@@ -23,16 +23,22 @@ describe("activityMaxAge", () => {
   });
 });
 
-describe("cachePolicy", () => {
-  const now = new Date("2026-07-06T12:30:00Z");
-
-  it("uses the default policy outside /activity", () => {
-    expect(cachePolicy("/posts/some-post/", now)).toEqual(DEFAULT_CACHE_POLICY);
-    expect(cachePolicy("/", now)).toEqual(DEFAULT_CACHE_POLICY);
+describe("isActivityPath", () => {
+  it("matches the routes whose freshness tracks the sync", () => {
+    expect(isActivityPath("/activity/code")).toBe(true);
+    expect(isActivityPath("/activity/code/2024")).toBe(true);
   });
 
-  it("aligns /activity max-age to the next data sync", () => {
-    expect(cachePolicy("/activity/code", now)).toEqual({
+  it("leaves everything else to routeRules", () => {
+    expect(isActivityPath("/")).toBe(false);
+    expect(isActivityPath("/posts/some-post")).toBe(false);
+    expect(isActivityPath("/llms.txt")).toBe(false);
+  });
+});
+
+describe("activityCachePolicy", () => {
+  it("aligns max-age to the next data sync", () => {
+    expect(activityCachePolicy(new Date("2026-07-06T12:30:00Z"))).toEqual({
       maxAge: 2100,
       swr: 3600,
     });

--- a/src/middleware/cache.ts
+++ b/src/middleware/cache.ts
@@ -1,9 +1,9 @@
 // Activity pages render from D1 that the github worker cron ("0 * * * *")
 // refreshes at the top of every hour. Their max-age expires just after the
 // next sync completes, so cached responses only bust when new data can
-// actually exist. Everything else changes only on deploy, and the Workers
-// Cache key includes the Worker version, so deploys invalidate it
-// regardless of TTL.
+// actually exist. Everything else changes only on deploy and is covered by
+// `routeRules` in astro.config.ts, and the Workers Cache key includes the
+// Worker version, so deploys invalidate it regardless of TTL.
 const ACTIVITY_SYNC_BUFFER_SECONDS = 300;
 
 export interface CachePolicy {
@@ -11,15 +11,11 @@ export interface CachePolicy {
   swr: number;
 }
 
-export const DEFAULT_CACHE_POLICY: CachePolicy = {
-  maxAge: 3600,
-  swr: 86400,
-};
+export function isActivityPath(pathname: string): boolean {
+  return pathname.startsWith("/activity");
+}
 
-export function cachePolicy(pathname: string, now: Date): CachePolicy {
-  if (!pathname.startsWith("/activity")) {
-    return DEFAULT_CACHE_POLICY;
-  }
+export function activityCachePolicy(now: Date): CachePolicy {
   return { maxAge: activityMaxAge(now), swr: 3600 };
 }
 


### PR DESCRIPTION
> Stacked on #549, which is stacked on #548. This PR's diff is against `astro-7-md-urls`.

## Why

Cache policy for routes that only change on deploy is a constant, so it belongs in config rather than being recomputed in middleware on every request. `routeRules` is the Astro 7 config for exactly this.

It's stacked rather than independent because `/llms.txt` arrives in #549 and is server-rendered. Narrowing the middleware without adding a rule for it would silently leave it uncached.

## The part that isn't a drop-in

`routeRules` does **not** apply the guards the middleware had. Reading `core/cache/runtime/cache.js`, a route rule is just a pre-seeded `cache.set()` applied when the cache object is created, which is *before the response exists*. `APPLY_HEADERS` then writes the header regardless of response status or an existing `Cache-Control`.

So declaring `{maxAge: 3600}` for `/posts/[...slug]` caches 404s. I verified this rather than assuming it, by deleting the guard and rebuilding:

| | `/posts/does-not-exist` |
| --- | --- |
| guard removed | `404` + `max-age=3600, stale-while-revalidate=86400` |
| guard present | `404` + `no-store` |

The middleware therefore opts back out explicitly with `cache.set(false)` for non-200 responses and for responses that already carry `Cache-Control`. Net line count is roughly a wash. The gain is that the policy is visible in config instead of implied by a function, not that there is less code.

## Verification

`astro build` + `wrangler dev`, reading `Cloudflare-CDN-Cache-Control`:

| Route | Result |
| --- | --- |
| `/`, `/about`, `/about.md`, `/posts/<slug>`, `/posts/<slug>.md`, `/og.png`, `/llms.txt` | `public, max-age=3600, stale-while-revalidate=86400` |
| `/activity/code` | `public, max-age=1577, stale-while-revalidate=3600`, shrinking through the hour |
| `/posts/does-not-exist` | `no-store` |

The cron alignment survives, which was the requirement. `cache.test.ts` is updated for the narrowed responsibility, covering the sync-aligned max-age boundaries and which paths the middleware still claims. `astro check` and `eslint` are clean.

## Note

Prerendered routes (`/archives`, `/tags/*`, `/posts/page/*`, `/rss.xml`) need no entries. `routeRules` uses route patterns, not globs, so `[...rest]` syntax is required.