### PR TITLE
chore: add JSON dev logging and document the background dev server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,29 @@ Personal website/blog: Astro → Cloudflare Workers. TailwindCSS v4, Vue, npm wo
 
 ```bash
 npm run dev           # Spotlight + Astro dev server
+npm run dev:json      # Astro dev server with JSON logs (no Spotlight)
 npm run build         # packages → wrangler types → astro check → astro build
 npm run lint          # ESLint
 npm run format        # Prettier
 ```
+
+### Background Dev Server
+
+`npm run dev` wraps `spotlight run astro dev`, which holds the terminal. To
+drive the server without blocking, call the Astro CLI directly:
+
+```bash
+astro dev --background    # start detached
+astro dev status          # is one running?
+astro dev logs --follow   # tail its output
+astro dev stop            # shut it down
+curl localhost:4321/_astro/status
+```
+
+Astro detects agents and turns on background mode plus JSON logging by itself,
+so these flags are usually unnecessary. Set `ASTRO_DEV_BACKGROUND=0` to force a
+foreground run, which is the only way to see startup errors that kill the
+process before it is ready.
 
 ## Stop Hook
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, envField } from "astro/config";
+import { defineConfig, envField, logHandlers } from "astro/config";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
 import sentry from "@sentry/astro";
@@ -42,6 +42,9 @@ function copyStaticFiles(src: string, dest: string) {
 export default defineConfig({
   site: SITE.website,
   output: "server",
+  // Interactive runs stay human-readable. `npm run dev:json` opts into
+  // machine-readable logs for tools that parse them.
+  ...(process.env.ASTRO_LOG_JSON ? { logger: logHandlers.json() } : {}),
   adapter: cloudflare({
     imageService: "compile",
   }),

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "dev": "spotlight run astro dev",
+    "dev:json": "ASTRO_LOG_JSON=1 astro dev",
     "build": "npm run build:packages && npm run types:generate && astro check && astro build",
     "build:packages": "npm run build --workspace=packages/logger -- --force && npm run build --workspace=packages/github -- --force",
     "preview": "astro preview",


### PR DESCRIPTION
Independent of #548/#549/#550. Touches only `package.json`, `astro.config.ts`, and `CLAUDE.md`.

## Why

`npm run dev` wraps `spotlight run astro dev`, which holds the terminal and prints for humans. Neither suits a tool reading the output.

## Changes

`npm run dev:json` sets `ASTRO_LOG_JSON` to swap in `logHandlers.json()`. Gating on the variable rather than replacing the logger outright keeps interactive runs readable:

```
{"message":"Enabling sessions with Cloudflare KV with the \"SESSION\" KV binding.","label":"@astrojs/cloudflare","level":"info"}
{"message":"connected.","label":"vite","level":"info"}
```

`CLAUDE.md` documents `astro dev --background`, `status`, `logs --follow`, `stop`, and `/_astro/status`. Astro turns background mode and JSON logging on by itself when it detects an agent, so this is mostly a map rather than configuration.

The exception worth writing down is `ASTRO_DEV_BACKGROUND=0`. Because agent detection forces background mode, a dev server that dies during startup reports only `Dev server process exited before becoming ready`, and `astro dev logs` then says no server is running. A foreground run is the only way to see the actual error.

## Heads up: `astro dev` is currently broken in this repo

Unrelated to this PR, and worth its own issue. On a branch off `main` with only these three files changed:

```
$ ASTRO_DEV_BACKGROUND=0 astro dev
...
Missing field `moduleType`
    at runInRunnerObject (workers/runner-worker/index.js:107:3)
```

It dies at wrangler runner init before serving anything, so the `/_astro/status` example above is documented from the CLI surface and Astro's `vite-plugin-dev-status`, not exercised end to end. `astro build` plus `wrangler dev` works fine and is what I used to verify the other PRs in this series.

The JSON logging in this PR *was* verified: the handler runs before the runner failure, so the lines above are real output.