### PR TITLE
refactor: drop dead /404 route rule

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -58,7 +58,6 @@ export default defineConfig({
   // in src/middleware.ts. Prerendered routes are not cached at runtime.
   routeRules: {
     "/": DEPLOY_SCOPED_CACHE,
-    "/404": DEPLOY_SCOPED_CACHE,
     "/about": DEPLOY_SCOPED_CACHE,
     "/about.md": DEPLOY_SCOPED_CACHE,
     "/posts/[...slug]": DEPLOY_SCOPED_CACHE,


### PR DESCRIPTION
Cleanup missed on [#553](https://github.com/bendrucker/bendrucker.me/pull/553#pullrequestreview-4739249706).

The `/404` entry in `routeRules` can never take effect. The cache middleware calls `context.cache.set(false)` for any response whose status is not 200, and `404.astro` is server-rendered, so it always returns 404. The seeded `DEPLOY_SCOPED_CACHE` policy is overridden before the response is sent.

## Verification

`astro build` + `wrangler dev`, reading `Cloudflare-CDN-Cache-Control`. Identical before and after removing the entry:

| Route | Before | After |
| --- | --- | --- |
| `/404` | `no-store` | `no-store` |
| `/posts/does-not-exist` | `no-store` | `no-store` |
| `/`, `/about` | `public, max-age=3600, stale-while-revalidate=86400` | same |

`/404` already emitted `no-store` with the entry present, which is what makes the removal a no-op rather than a behavior change.

`eslint` is clean. The existing suite covering the middleware's cache decisions is unchanged and still green, which is expected since no behavior moved.
