### PR TITLE
fix: add H1 title to about and post markdown

### DIFF
--- a/src/representations/about.test.ts
+++ b/src/representations/about.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import type { APIContext } from "astro";
+import { about } from "./about";
+
+const context = {} as APIContext;
+
+describe("about", () => {
+  it("renders with an H1 title above the body", async () => {
+    const md = await about.render(context);
+    expect(md?.startsWith("# About\n\n")).toBe(true);
+    expect(md).toContain("## Code");
+  });
+
+  it("strips the frontmatter", async () => {
+    const md = await about.render(context);
+    expect(md).not.toContain("layout:");
+  });
+
+  it("lists itself once", async () => {
+    const entries = await about.list();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe("/about");
+    expect(entries[0].title).toBe("About");
+  });
+});

--- a/src/representations/about.test.ts
+++ b/src/representations/about.test.ts
@@ -8,7 +8,7 @@ describe("about", () => {
   it("renders with an H1 title above the body", async () => {
     const md = await about.render(context);
     expect(md?.startsWith("# About\n\n")).toBe(true);
-    expect(md).toContain("## Code");
+    expect(md).toMatch(/\n## /);
   });
 
   it("strips the frontmatter", async () => {

--- a/src/representations/about.ts
+++ b/src/representations/about.ts
@@ -7,7 +7,8 @@ const FRONTMATTER = /^---\r?\n[\s\S]*?\r?\n---\r?\n/;
 export const about: Representation = {
   route: "/about",
   section: "Pages",
-  render: async () => aboutMd.replace(FRONTMATTER, "").trimStart(),
+  render: async () =>
+    `# About\n\n${aboutMd.replace(FRONTMATTER, "").trimStart()}`,
   list: async () => [
     {
       path: "/about",

--- a/src/representations/posts.test.ts
+++ b/src/representations/posts.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import type { APIContext } from "astro";
+
+const entry = {
+  id: "hello-world",
+  filePath: "src/content/blog/hello-world.md",
+  body: "The body of the post.",
+  data: { title: "Hello, World", draft: false, pubDatetime: "2013-01-01" },
+};
+
+vi.mock("astro:content", () => ({
+  getCollection: (_collection: string, filter?: (e: unknown) => boolean) =>
+    Promise.resolve([entry].filter((e) => (filter ? filter(e) : true))),
+}));
+
+const { posts } = await import("./posts");
+
+function context(slug: string): APIContext {
+  return { params: { slug } } as unknown as APIContext;
+}
+
+describe("posts", () => {
+  it("renders the post title as an H1 above the body", async () => {
+    const md = await posts.render(context("hello-world"));
+    expect(md).toBe("# Hello, World\n\nThe body of the post.");
+  });
+
+  it("falls through to HTML for an unknown slug", async () => {
+    expect(await posts.render(context("nope"))).toBeNull();
+  });
+
+  it("falls through to HTML when no slug is given", async () => {
+    expect(await posts.render(context(""))).toBeNull();
+  });
+});

--- a/src/representations/posts.test.ts
+++ b/src/representations/posts.test.ts
@@ -32,4 +32,15 @@ describe("posts", () => {
   it("falls through to HTML when no slug is given", async () => {
     expect(await posts.render(context(""))).toBeNull();
   });
+
+  it("lists each published post once", async () => {
+    const entries = await posts.list();
+    expect(entries).toEqual([
+      {
+        path: "/posts/hello-world",
+        title: "Hello, World",
+        description: undefined,
+      },
+    ]);
+  });
 });

--- a/src/representations/posts.ts
+++ b/src/representations/posts.ts
@@ -15,7 +15,8 @@ export const posts: Representation = {
     const entry = entries.find(
       (post) => getPath(post.id, post.filePath) === `/posts/${slug}`,
     );
-    return entry?.body ?? null;
+    if (entry?.body === undefined) return null;
+    return `# ${entry.data.title}\n\n${entry.body}`;
   },
 
   async list() {

--- a/src/representations/posts.ts
+++ b/src/representations/posts.ts
@@ -15,7 +15,7 @@ export const posts: Representation = {
     const entry = entries.find(
       (post) => getPath(post.id, post.filePath) === `/posts/${slug}`,
     );
-    if (entry?.body === undefined) return null;
+    if (entry?.body == null) return null;
     return `# ${entry.data.title}\n\n${entry.body}`;
   },
 


### PR DESCRIPTION
The `text/markdown` representations for `/about` and blog posts were served with no top-level heading. `/about` began at `## Code` and posts began at the body, so a client fetching the markdown (or the `.md` sibling) got a document with no title. The activity representations already prepend an H1, so this brings the other two in line.

`/about` now renders `# About` and posts render `# {post title}` above the body, both drawn from the page title.

While tightening `posts`, the null guard moved from `entry?.body ?? null` to `entry?.body == null`, which keeps the same breadth (missing entry or missing body both fall through to HTML).

Adds tests for both representations, which previously had none.
