### PR TITLE
chore: add design-sync inputs for claude.ai/design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -61,7 +61,7 @@ entry even with zero components. Recreate it if `tmp/` was cleaned.
 
 ## Known validate warns
 
-Both are expected. A warn *not* on this list is new.
+Both are expected. A warn _not_ on this list is new.
 
 - `[TOKENS_MISSING]`: `--shiki-light`, `--shiki-dark`, `--shiki-light-bg`,
   `--shiki-dark-bg`, `--file-name-offset`. All five are injected inline per code

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,93 @@
+# design-sync notes
+
+## What this repo syncs
+
+bendrucker.me is an Astro site, not a React design system. It has **no components
+to sync**: `src/components/` is 12 `.astro` files plus 8 `.vue` files, and no
+workspace package exports UI. The converter runs in its `[ZERO_MATCH]` tokens-only
+mode: empty `_ds_bundle.js`, everything of value in `styles.css`.
+
+The deliverable is therefore `.design-sync/conventions.md`, which is prepended to
+the uploaded README and inlined into the design agent's system prompt. It is the
+only thing telling the agent what vocabulary exists. Keep it accurate.
+
+## Build recipe
+
+The site's `src/styles/global.css` cannot ship as-is. It is Tailwind v4 source
+(`@import "tailwindcss"`, `@plugin`, `@apply`, `@theme inline`), and nothing
+downstream resolves those. Compile it first:
+
+```sh
+npm ci
+# @tailwindcss/cli is not a dependency. Install it transiently, matching the
+# tailwindcss version in package.json.
+npm i --no-save --no-package-lock @tailwindcss/cli@4.3.2
+
+npx tailwindcss -i .design-sync/tailwind-entry.css -o tmp/ds/compiled.css
+node .ds-sync/resync.mjs --config .design-sync/config.json \
+  --node-modules ./.ds-sync/node_modules --entry ./tmp/ds/entry.mjs \
+  --out ./ds-bundle --no-render-check
+```
+
+`tmp/ds/entry.mjs` is a one-line `export {};`. The converter requires a bundle
+entry even with zero components. Recreate it if `tmp/` was cleaned.
+
+- **`.design-sync/tailwind-entry.css` is the important file.** It wraps the real
+  `global.css` and safelists the class vocabulary. Tailwind never runs downstream,
+  so a class absent from the compiled output silently does nothing in every design
+  the agent builds. The safelist is what makes `gap-4`, `m-2`, `grid-cols-3` etc.
+  exist at all. Without it the output was 941 utility rules and full of holes.
+  With it, 4036.
+- **Keep the `@source not` exclusions.** Tailwind's auto-detection scans the whole
+  repo and honors only the repo `.gitignore`, never the user's global one. Without
+  them it scans `.worktrees/` and `tmp/`, treats class names quoted in these very
+  docs as real usage, and fails on the literal `icon-[ph--*]` they mention. That
+  scraped ~3KB of junk rules into the stylesheet before it was caught.
+- Re-run the compile whenever `src/styles/*.css` changes. `cfg.cssEntry` points at
+  the compiled output, not the source.
+
+## Environment gotchas
+
+- **React is not a dependency of this repo.** The converter vendors React for
+  preview cards regardless of component count, so it was installed into
+  `.ds-sync/node_modules` (isolated) and `--node-modules` points there, not at the
+  repo's own `node_modules`. Do not add React to `package.json`.
+- `npm ci` is required first. A bare checkout leaves `node_modules` nearly empty
+  and `npx tailwindcss` won't resolve. `@tailwindcss/cli` is not a dependency;
+  install it transiently with `npm i --no-save --no-package-lock @tailwindcss/cli@<matching version>`.
+  Match the version to `tailwindcss` in `package.json`.
+- `node_modules` is no longer tracked in git. An older note claimed it was a
+  self-referential symlink, but that was fixed upstream. `npm ci` is safe.
+
+## Known validate warns
+
+Both are expected. A warn *not* on this list is new.
+
+- `[TOKENS_MISSING]`: `--shiki-light`, `--shiki-dark`, `--shiki-light-bg`,
+  `--shiki-dark-bg`, `--file-name-offset`. All five are injected inline per code
+  block at runtime (`src/shiki/fileName.js:22`), never declared in a stylesheet.
+  Correctly absent. Do not chase.
+- `[RENDER_SKIPPED]`: accepted deliberately via `--no-render-check`. Playwright is
+  not installed and the bundle has zero preview cards, so the check would open zero
+  files. If components ever exist, install Playwright and drop the flag.
+
+## Re-sync risks
+
+- **The conventions file rots silently.** It enumerates concrete class names and
+  hexes. If `src/styles/global.css` changes a token value or the safelist in
+  `tailwind-entry.css` drifts, the file will confidently name vocabulary that no
+  longer resolves. Re-validate every class and hex in it against the fresh
+  `ds-bundle/_ds_bundle.css` on each sync. That check is cheap and was done on the
+  first sync.
+- **Accent hue flips between themes** (`#006cac` light → `#ff6b01` dark). If either
+  changes, update the color table in `conventions.md`.
+- **Arbitrary-value classes never work downstream** (`w-[327px]`, `icon-[ph--*]`).
+  The safelist cannot cover them by definition. This is documented in the
+  conventions file; keep that caveat if the file is rewritten.
+- The site's Phosphor icons compile into `#about h2::after` selectors via `@apply`,
+  not as reusable `icon-[...]` utilities, so the agent has no icon vocabulary. If
+  icons ever matter, safelist specific `icon-[ph--*]` classes in
+  `tailwind-entry.css`.
+- If this repo ever grows a real React component package, this shape assumption
+  changes entirely. Rerun detection rather than reusing `cfg.shape: "package"`
+  with the empty entry.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,8 @@
+{
+  "projectId": "698b5056-b116-4744-891c-ccae66e9b29b",
+  "shape": "package",
+  "pkg": "bendrucker.me",
+  "globalName": "BendruckerMe",
+  "cssEntry": "tmp/ds/compiled.css",
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -38,13 +38,13 @@ Don't re-declare them on a wrapper.
 Five semantic colors, and only five. There is no numeric palette. Never write
 `bg-gray-100`, `text-slate-700`, or any other Tailwind default color.
 
-| Token         | Utility root | Light     | Dark      | Use                       |
-| ------------- | ------------ | --------- | --------- | ------------------------- |
-| `--background`| `background` | `#fdfdfd` | `#212737` | Page and surface fills    |
-| `--foreground`| `foreground` | `#282728` | `#eaedf3` | Body text                 |
-| `--accent`    | `accent`     | `#006cac` | `#ff6b01` | Links, focus, emphasis    |
-| `--muted`     | `muted`      | `#e6e6e6` | `#343f60` | Secondary fills, chips    |
-| `--border`    | `border`     | `#ece9e9` | `#ab4b08` | Rules, dividers, outlines |
+| Token          | Utility root | Light     | Dark      | Use                       |
+| -------------- | ------------ | --------- | --------- | ------------------------- |
+| `--background` | `background` | `#fdfdfd` | `#212737` | Page and surface fills    |
+| `--foreground` | `foreground` | `#282728` | `#eaedf3` | Body text                 |
+| `--accent`     | `accent`     | `#006cac` | `#ff6b01` | Links, focus, emphasis    |
+| `--muted`      | `muted`      | `#e6e6e6` | `#343f60` | Secondary fills, chips    |
+| `--border`     | `border`     | `#ece9e9` | `#ab4b08` | Rules, dividers, outlines |
 
 **The accent shifts hue between themes**: blue in light, orange in dark. That is
 deliberate. Never hardcode either hex; always go through `accent` so both themes
@@ -105,7 +105,10 @@ samples with `bg-muted` and `text-foreground` instead.
 
   <ul class="flex flex-col gap-6">
     <li class="border-b border-border pb-6">
-      <a href="#" class="text-xl text-foreground decoration-dashed underline-offset-4 hover:text-accent">
+      <a
+        href="#"
+        class="text-xl text-foreground decoration-dashed underline-offset-4 hover:text-accent"
+      >
         Caching at the edge
       </a>
       <p class="mt-1 text-sm text-foreground/60">March 2026</p>
@@ -115,7 +118,9 @@ samples with `bg-muted` and `text-foreground` instead.
     </li>
   </ul>
 
-  <button class="mt-8 rounded border border-border bg-muted px-4 py-2 text-foreground hover:bg-accent hover:text-background">
+  <button
+    class="mt-8 rounded border border-border bg-muted px-4 py-2 text-foreground hover:bg-accent hover:text-background"
+  >
     Load more
   </button>
 </section>

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,122 @@
+# bendrucker.me — Theme Only, No Components
+
+**This design system ships no components.** `_ds_bundle.js` is empty and
+`window.BendruckerMe` has no exports. Ignore the "0 components" phrasing and the
+`window.BendruckerMe.*` loading example further down. There is nothing to import.
+Build with plain HTML elements and style them using the vocabulary below.
+
+The source is [bendrucker.me](https://bendrucker.me), a personal site built in Astro.
+What is bound here is its real compiled stylesheet: the theme tokens, the base
+element styles, and the Tailwind utilities generated from them.
+
+## Setup
+
+Link the stylesheet and set a theme on the root element. There is no provider and
+no JavaScript to load.
+
+```html
+<html data-theme="light">
+  <head>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    ...
+  </body>
+</html>
+```
+
+`data-theme` must be `light` or `dark`. The dark palette only applies under
+`html[data-theme="dark"]`, so omitting it leaves the page in light mode regardless
+of the viewer's OS setting.
+
+`<body>` already carries the brand defaults: `--background`, `--foreground`,
+monospace type, and `display: flex; flex-direction: column; min-height: 100svh`.
+Don't re-declare them on a wrapper.
+
+## Colors
+
+Five semantic colors, and only five. There is no numeric palette. Never write
+`bg-gray-100`, `text-slate-700`, or any other Tailwind default color.
+
+| Token         | Utility root | Light     | Dark      | Use                       |
+| ------------- | ------------ | --------- | --------- | ------------------------- |
+| `--background`| `background` | `#fdfdfd` | `#212737` | Page and surface fills    |
+| `--foreground`| `foreground` | `#282728` | `#eaedf3` | Body text                 |
+| `--accent`    | `accent`     | `#006cac` | `#ff6b01` | Links, focus, emphasis    |
+| `--muted`     | `muted`      | `#e6e6e6` | `#343f60` | Secondary fills, chips    |
+| `--border`    | `border`     | `#ece9e9` | `#ab4b08` | Rules, dividers, outlines |
+
+**The accent shifts hue between themes**: blue in light, orange in dark. That is
+deliberate. Never hardcode either hex; always go through `accent` so both themes
+stay correct.
+
+Each root combines with these prefixes: `bg-`, `text-`, `border-`, `outline-`,
+`decoration-`, `fill-`, `stroke-`, `ring-`, `divide-`, `caret-`, `shadow-`,
+`accent-`. Opacity suffixes are available on `bg-`, `text-`, `border-`, `outline-`,
+`fill-`, and `ring-` at `/5` through `/95`, e.g. `bg-accent/10`, `text-foreground/70`.
+Variants `hover:`, `focus-visible:`, `dark:`, `sm:`, `md:`, `lg:` are compiled for
+`bg-`, `text-`, `border-`, and `outline-`.
+
+Prefer plain utilities over `dark:`. The tokens already flip with the theme.
+Reach for `dark:` only when a rule genuinely differs per theme.
+
+## Type and Layout
+
+- **Everything is monospace.** `body` sets `var(--font-mono)`. This is the single
+  most recognizable trait of the site. Keep it. Use `font-sans` or `font-serif`
+  only for a deliberate contrast.
+- `max-w-app` is the page width (48rem). `<section>` and `<footer>` already get
+  `mx-auto max-w-app px-4` from the base layer, so a plain `<section>` is the
+  correct page container, with no wrapper divs needed.
+- `.app-prose` styles long-form article content (headings, lists, tables, links,
+  inline code) in the site's voice. Put it on the container of rendered markdown,
+  not on individual elements.
+- `<a>` and `<button>` already carry the focus treatment: a dashed accent outline
+  on `:focus-visible`. Don't rebuild it.
+
+Standard Tailwind spacing, sizing, flex, grid, border, radius, shadow, and
+transition utilities are compiled and safe to use, including `sm:`/`md:`/`lg:`
+variants for the common layout families.
+
+## Constraint: The Stylesheet Is Precompiled
+
+Tailwind does not run downstream. `styles.css` is a fixed file, so **a class that
+isn't already in it does nothing**. It fails silently, with no error. Two rules
+follow:
+
+- Arbitrary-value classes (`w-[327px]`, `bg-[#ff0000]`, `icon-[ph--code-light]`)
+  will not resolve. Use an inline `style` attribute or a `<style>` block with
+  `var(--accent)` etc. when you need a one-off value.
+- Before relying on an unusual utility, grep for it in `_ds_bundle.css` (which
+  `styles.css` imports). The five color roots and the layout families above are
+  guaranteed; the long tail is not.
+
+Code blocks (`.astro-code`) read `--shiki-light`, `--shiki-dark`,
+`--shiki-light-bg`, `--shiki-dark-bg`, set inline per block by the site's build.
+Those are absent here, so syntax highlighting will not reproduce. Style code
+samples with `bg-muted` and `text-foreground` instead.
+
+## Example
+
+```html
+<section class="py-12">
+  <h1 class="mb-2 text-3xl font-bold text-foreground">Posts</h1>
+  <p class="mb-8 text-foreground/70">Notes on infrastructure and tooling.</p>
+
+  <ul class="flex flex-col gap-6">
+    <li class="border-b border-border pb-6">
+      <a href="#" class="text-xl text-foreground decoration-dashed underline-offset-4 hover:text-accent">
+        Caching at the edge
+      </a>
+      <p class="mt-1 text-sm text-foreground/60">March 2026</p>
+      <p class="mt-3 text-foreground/80">
+        What the Workers Cache API scopes to, and why that shapes purge design.
+      </p>
+    </li>
+  </ul>
+
+  <button class="mt-8 rounded border border-border bg-muted px-4 py-2 text-foreground hover:bg-accent hover:text-background">
+    Load more
+  </button>
+</section>
+```

--- a/.design-sync/tailwind-entry.css
+++ b/.design-sync/tailwind-entry.css
@@ -1,0 +1,86 @@
+/* Build entry for the claude.ai/design sync (see .design-sync/NOTES.md).
+   Wraps the site's real global.css and safelists the vocabulary the design
+   agent needs, since the uploaded stylesheet is precompiled and Tailwind
+   never runs again downstream. */
+
+@import "../src/styles/global.css";
+
+@source "../src";
+/* Tailwind's automatic detection scans the whole repo and honors only the repo
+   .gitignore, never the user's global one. `.worktrees/` and `tmp/` are ignored
+   globally here, so without these it scans them, reads class names quoted in
+   NOTES.md and conventions.md as real usage, and fails on the literal
+   `icon-[ph--*]` those files document. */
+@source not "../.design-sync";
+@source not "../.worktrees";
+@source not "../tmp";
+
+/* Semantic theme colors across every utility family that accepts a color. */
+@source inline(
+  "{bg,text,border,outline,decoration,fill,stroke,ring,divide,accent,caret,shadow}-{background,foreground,accent,muted,border}"
+);
+@source inline(
+  "{bg,text,border,outline,fill,ring}-{background,foreground,accent,muted,border}/{5,10,15,20,25,30,40,50,60,70,75,80,85,90,95}"
+);
+@source inline(
+  "{hover,focus-visible,dark,sm,md,lg}:{bg,text,border,outline}-{background,foreground,accent,muted,border}"
+);
+
+/* Spacing scale: padding, margin, gap, and the space-between helpers. */
+@source inline(
+  "{,sm:,md:,lg:}{p,px,py,pt,pr,pb,pl,m,mx,my,mt,mr,mb,ml,gap,gap-x,gap-y,space-x,space-y}-{0,px,0.5,1,1.5,2,2.5,3,3.5,4,5,6,7,8,9,10,11,12,14,16,20,24,28,32,40,48,56,64}"
+);
+@source inline("{mx,my,mt,mb}-auto");
+
+/* Sizing. */
+@source inline(
+  "{,sm:,md:,lg:}{w,h,min-w,min-h,max-w,max-h}-{0,px,1,2,3,4,5,6,8,10,12,16,20,24,32,40,48,56,64,full,screen,auto,fit,min,max}"
+);
+@source inline("max-w-{xs,sm,md,lg,xl,2xl,3xl,4xl,5xl,6xl,7xl,prose,app}");
+
+/* Layout, flexbox, and grid. */
+@source inline(
+  "{,sm:,md:,lg:}{block,inline-block,inline,flex,inline-flex,grid,inline-grid,contents,hidden}"
+);
+@source inline("{,sm:,md:,lg:}flex-{row,row-reverse,col,col-reverse,wrap,nowrap,1,auto,initial,none}");
+@source inline("items-{start,end,center,baseline,stretch}");
+@source inline("justify-{start,end,center,between,around,evenly}");
+@source inline("self-{auto,start,end,center,stretch}");
+@source inline("{,sm:,md:,lg:}grid-cols-{1,2,3,4,5,6,7,8,9,10,11,12,none}");
+@source inline("{,sm:,md:,lg:}col-span-{1,2,3,4,5,6,7,8,9,10,11,12,full}");
+@source inline("{static,relative,absolute,fixed,sticky}");
+@source inline("{inset,top,right,bottom,left}-{0,px,1,2,3,4,6,8,auto,full}");
+@source inline("z-{0,10,20,30,40,50,auto}");
+@source inline("overflow-{auto,hidden,visible,scroll,clip}");
+@source inline("{overflow-x,overflow-y}-{auto,hidden,visible,scroll,clip}");
+
+/* Typography. */
+@source inline("{,sm:,md:,lg:}text-{xs,sm,base,lg,xl,2xl,3xl,4xl,5xl,6xl,7xl}");
+@source inline("font-{sans,serif,mono}");
+@source inline("font-{thin,light,normal,medium,semibold,bold,extrabold,black}");
+@source inline("text-{left,center,right,justify}");
+@source inline("{italic,not-italic,uppercase,lowercase,capitalize,normal-case,truncate}");
+@source inline("{underline,line-through,no-underline,overline}");
+/* The site uses these in its own markup, so a source scan happens to emit them.
+   Safelist them anyway: conventions.md's example depends on them, and a markup
+   change elsewhere must not silently drop them. */
+@source inline("decoration-{solid,double,dotted,dashed,wavy,none}");
+@source inline("decoration-{0,1,2,4,8}");
+@source inline("underline-offset-{0,1,2,4,8,auto}");
+@source inline("leading-{none,tight,snug,normal,relaxed,loose,3,4,5,6,7,8,9,10}");
+@source inline("tracking-{tighter,tight,normal,wide,wider,widest}");
+@source inline("whitespace-{normal,nowrap,pre,pre-line,pre-wrap}");
+@source inline("break-{normal,words,all,keep}");
+
+/* Borders, radius, shadow, and effects. */
+@source inline("border-{0,2,4,8}");
+@source inline("{border-t,border-r,border-b,border-l,border-x,border-y}-{0,2,4,8}");
+@source inline("border-{solid,dashed,dotted,double,none}");
+@source inline("rounded-{none,sm,md,lg,xl,2xl,3xl,full}");
+@source inline("{rounded-t,rounded-r,rounded-b,rounded-l}-{none,sm,md,lg,xl,2xl,3xl,full}");
+@source inline("shadow-{none,sm,md,lg,xl,2xl,inner}");
+@source inline("opacity-{0,5,10,20,25,30,40,50,60,70,75,80,90,95,100}");
+@source inline("{cursor-pointer,cursor-default,cursor-not-allowed,select-none,pointer-events-none}");
+@source inline("transition-{none,all,colors,opacity,shadow,transform}");
+@source inline("duration-{75,100,150,200,300,500,700,1000}");
+@source inline("ease-{linear,in,out,in-out}");

--- a/.design-sync/tailwind-entry.css
+++ b/.design-sync/tailwind-entry.css
@@ -42,7 +42,9 @@
 @source inline(
   "{,sm:,md:,lg:}{block,inline-block,inline,flex,inline-flex,grid,inline-grid,contents,hidden}"
 );
-@source inline("{,sm:,md:,lg:}flex-{row,row-reverse,col,col-reverse,wrap,nowrap,1,auto,initial,none}");
+@source inline(
+  "{,sm:,md:,lg:}flex-{row,row-reverse,col,col-reverse,wrap,nowrap,1,auto,initial,none}"
+);
 @source inline("items-{start,end,center,baseline,stretch}");
 @source inline("justify-{start,end,center,between,around,evenly}");
 @source inline("self-{auto,start,end,center,stretch}");
@@ -59,7 +61,9 @@
 @source inline("font-{sans,serif,mono}");
 @source inline("font-{thin,light,normal,medium,semibold,bold,extrabold,black}");
 @source inline("text-{left,center,right,justify}");
-@source inline("{italic,not-italic,uppercase,lowercase,capitalize,normal-case,truncate}");
+@source inline(
+  "{italic,not-italic,uppercase,lowercase,capitalize,normal-case,truncate}"
+);
 @source inline("{underline,line-through,no-underline,overline}");
 /* The site uses these in its own markup, so a source scan happens to emit them.
    Safelist them anyway: conventions.md's example depends on them, and a markup
@@ -67,20 +71,28 @@
 @source inline("decoration-{solid,double,dotted,dashed,wavy,none}");
 @source inline("decoration-{0,1,2,4,8}");
 @source inline("underline-offset-{0,1,2,4,8,auto}");
-@source inline("leading-{none,tight,snug,normal,relaxed,loose,3,4,5,6,7,8,9,10}");
+@source inline(
+  "leading-{none,tight,snug,normal,relaxed,loose,3,4,5,6,7,8,9,10}"
+);
 @source inline("tracking-{tighter,tight,normal,wide,wider,widest}");
 @source inline("whitespace-{normal,nowrap,pre,pre-line,pre-wrap}");
 @source inline("break-{normal,words,all,keep}");
 
 /* Borders, radius, shadow, and effects. */
 @source inline("border-{0,2,4,8}");
-@source inline("{border-t,border-r,border-b,border-l,border-x,border-y}-{0,2,4,8}");
+@source inline(
+  "{border-t,border-r,border-b,border-l,border-x,border-y}-{0,2,4,8}"
+);
 @source inline("border-{solid,dashed,dotted,double,none}");
 @source inline("rounded-{none,sm,md,lg,xl,2xl,3xl,full}");
-@source inline("{rounded-t,rounded-r,rounded-b,rounded-l}-{none,sm,md,lg,xl,2xl,3xl,full}");
+@source inline(
+  "{rounded-t,rounded-r,rounded-b,rounded-l}-{none,sm,md,lg,xl,2xl,3xl,full}"
+);
 @source inline("shadow-{none,sm,md,lg,xl,2xl,inner}");
 @source inline("opacity-{0,5,10,20,25,30,40,50,60,70,75,80,90,95,100}");
-@source inline("{cursor-pointer,cursor-default,cursor-not-allowed,select-none,pointer-events-none}");
+@source inline(
+  "{cursor-pointer,cursor-default,cursor-not-allowed,select-none,pointer-events-none}"
+);
 @source inline("transition-{none,all,colors,opacity,shadow,transform}");
 @source inline("duration-{75,100,150,200,300,500,700,1000}");
 @source inline("ease-{linear,in,out,in-out}");

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ pnpm-debug.log*
 
 # TypeScript incremental build info
 tsconfig.tsbuildinfo
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
Adds the inputs for syncing this site's theme to a [Claude Design](https://claude.ai/design) project, so the design agent builds on-brand instead of with generic components.

The repo has no React component library to sync. `src/components/` is Astro and Vue, and no workspace package exports UI, so the converter runs in its tokens-only mode: an empty `_ds_bundle.js` and everything of value in the stylesheet. That was a deliberate choice over porting the components to React, which would have produced a parallel copy that drifts from the site.

## What each file does

`conventions.md` is the actual deliverable. It gets prepended to the uploaded README and inlined into the design agent's system prompt, which makes it the only thing telling the agent that the accent flips blue to orange between themes, that everything is monospace, and that there is no numeric color palette. An agent in that position can only follow guidance that names things concretely, so every class, token, and hex in it is enumerated rather than described. All of them were verified against the built stylesheet: the full color-by-prefix cross-product, the opacity and variant claims, and every class in the example snippet.

`tailwind-entry.css` wraps `src/styles/global.css` and safelists the vocabulary. This matters more than it looks. Tailwind never runs downstream, so the uploaded stylesheet is fixed, and a class missing from it fails silently in every design the agent ever builds. Compiling `global.css` as-is gave 941 utility rules with holes in obvious places like `gap-4`, `m-2`, and `grid-cols-3`. The safelist brings it to 4036.

`NOTES.md` carries the build recipe and the gotchas, so a future sync doesn't rediscover them.

## Two things worth flagging

The `@source not` exclusions in `tailwind-entry.css` are load-bearing. Tailwind's auto-detection scans the whole repo and honors only the repo `.gitignore`, never a global one. Since `.worktrees/` and `tmp/` are ignored globally here, it was scanning them, reading class names quoted in `NOTES.md` and `conventions.md` as real usage, and failing on the literal `icon-[ph--*]` those files document. It had scraped about 3KB of junk rules into the stylesheet before that was caught.

React is installed in the converter's isolated directory rather than here. It vendors React for preview cards whether or not any components exist, and adding it to `package.json` for a site that doesn't use it would be worse.

## Verification

`package-validate.mjs` exits 0 and the driver's final verdict is `ok: true` across build, diff, and validate. Two warnings are expected and recorded in `NOTES.md`: `[TOKENS_MISSING]` for five shiki variables that `src/shiki/fileName.js:22` injects inline per code block, and `[RENDER_SKIPPED]`, since Playwright isn't installed and the bundle has zero preview cards for a render check to open.

No application code changes, so CI here only exercises lint and formatting.
