### PR TITLE
greptile: stop re-reviewing on every push

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,3 +1,5 @@
 {
-  "strictness": 2
+  "strictness": 2,
+  "triggerOnUpdates": false,
+  "triggerOnDrafts": false
 }


### PR DESCRIPTION
Greptile bills a credit per review, and `triggerOnUpdates` charged again on every push. Across this repo, `bendrucker/claude`, and `bendrucker.me` that came to 352 PRs in 30 days against a 100-credit monthly allowance, which ran out on August 2.

Turning both triggers off means a PR draws at most one review, on demand. `bendrucker/claude` carries the matching skill changes: an importance gate that decides whether a diff is worth a review at all, and a cooldown cache so a session stops re-probing an exhausted provider.
