### PR TITLE
perf: guard D1 activity writes and version the dataset

### DIFF
--- a/migrations/0004_sync_state.sql
+++ b/migrations/0004_sync_state.sql
@@ -1,0 +1,9 @@
+CREATE TABLE sync_state (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  version INTEGER NOT NULL DEFAULT 0,
+  payload_hash TEXT,
+  changed_at TEXT NOT NULL DEFAULT (datetime('now')),
+  synced_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO sync_state (id) VALUES (1);

--- a/scripts/backfill-github-activity.ts
+++ b/scripts/backfill-github-activity.ts
@@ -13,7 +13,8 @@ import {
 } from "@workspace/github";
 import { logger } from "@workspace/logger";
 import { connectD1, formatSql, executeRemote } from "./d1";
-import { upsertRepo, upsertActivity } from "../src/activity/upsert";
+import { activityStatements } from "../src/activity/upsert";
+import { recordSync } from "../src/activity/sync-state";
 
 async function rateLimitBackoff(rateLimit: RateLimit): Promise<void> {
   const { remaining, cost, resetAt } = rateLimit;
@@ -177,25 +178,27 @@ async function main() {
   }
 
   const { db, dispose } = await connectD1();
+  const queries = activityStatements(db, allRepos);
+  // The backfill spans every year, so the hash the cron computes over the
+  // current year alone no longer describes what is stored. Clearing it makes
+  // the next cron run write, and reestablish, its own hash.
+  const sync = recordSync(db, { payloadHash: null, changed: true });
+
   try {
     if (remote) {
-      const statements = allRepos.flatMap((repo) => [
-        formatSql(upsertRepo(db, repo).compile()),
-        formatSql(upsertActivity(db, repo).compile()),
-      ]);
-      executeRemote(statements);
+      executeRemote([...queries, sync.compile()].map(formatSql));
     } else {
-      for (const repo of allRepos) {
-        await upsertRepo(db, repo).execute();
-        await upsertActivity(db, repo).execute();
+      for (const query of queries) {
+        await db.executeQuery(query);
       }
+      await sync.execute();
     }
   } finally {
     await dispose();
   }
 
   logger.info(
-    { statements: allRepos.length * 2, remote },
+    { statements: queries.length, remote },
     "Imported activity data to D1",
   );
 }

--- a/src/activity/sync-state.test.ts
+++ b/src/activity/sync-state.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Kysely } from "kysely";
+import type { Database } from "@/db";
+import { createTestDb } from "@/test/db";
+import type { RepoActivity } from "@workspace/github";
+import { hashStatements, readSyncState, recordSync } from "./sync-state";
+import { activityStatements } from "./upsert";
+
+function makeRepo(overrides: Partial<RepoActivity> = {}): RepoActivity {
+  return {
+    owner: "bendrucker",
+    name: "cool-lib",
+    description: "A cool library",
+    url: "https://github.com/bendrucker/cool-lib",
+    lastActivity: new Date("2025-06-01T00:00:00.000Z"),
+    createdAt: new Date("2020-01-01T00:00:00.000Z"),
+    primaryLanguage: { name: "TypeScript", color: "#3178c6" },
+    stargazerCount: 100,
+    activitySummary: {
+      prCount: 5,
+      reviewCount: 2,
+      issueCount: 1,
+      mergeCount: 3,
+      hasMergedPRs: true,
+    },
+    ...overrides,
+  };
+}
+
+describe("sync state", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("starts at version zero with no payload hash", async () => {
+    expect(await readSyncState(db)).toEqual({ version: 0, payloadHash: null });
+  });
+
+  it("bumps the version and records the hash on a real change", async () => {
+    const [{ version }] = await recordSync(db, {
+      payloadHash: "abc",
+      changed: true,
+    }).execute();
+
+    expect(version).toBe(1);
+    expect(await readSyncState(db)).toEqual({
+      version: 1,
+      payloadHash: "abc",
+    });
+  });
+
+  it("records the hash without bumping the version on a no-op run", async () => {
+    await recordSync(db, { payloadHash: "abc", changed: true }).execute();
+    const before = await db
+      .selectFrom("syncState")
+      .select("changedAt")
+      .executeTakeFirstOrThrow();
+
+    const [{ version }] = await recordSync(db, {
+      payloadHash: "reordered",
+      changed: false,
+    }).execute();
+
+    expect(version).toBe(1);
+    expect(await readSyncState(db)).toEqual({
+      version: 1,
+      payloadHash: "reordered",
+    });
+
+    const after = await db
+      .selectFrom("syncState")
+      .select("changedAt")
+      .executeTakeFirstOrThrow();
+    expect(after.changedAt).toBe(before.changedAt);
+  });
+});
+
+describe("hashStatements", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("ignores the order repos arrive in", async () => {
+    const repos = [
+      makeRepo({ owner: "bendrucker", name: "quibble" }),
+      makeRepo({ owner: "bendrucker", name: "cool-lib" }),
+    ];
+
+    expect(await hashStatements(activityStatements(db, repos))).toBe(
+      await hashStatements(activityStatements(db, [...repos].reverse())),
+    );
+  });
+
+  it("changes when any stored value changes", async () => {
+    const unchanged = await hashStatements(
+      activityStatements(db, [makeRepo()]),
+    );
+
+    expect(
+      await hashStatements(
+        activityStatements(db, [makeRepo({ stargazerCount: 101 })]),
+      ),
+    ).not.toBe(unchanged);
+
+    expect(
+      await hashStatements(
+        activityStatements(db, [
+          makeRepo({
+            activitySummary: {
+              prCount: 6,
+              reviewCount: 2,
+              issueCount: 1,
+              mergeCount: 3,
+              hasMergedPRs: true,
+            },
+          }),
+        ]),
+      ),
+    ).not.toBe(unchanged);
+  });
+});

--- a/src/activity/sync-state.ts
+++ b/src/activity/sync-state.ts
@@ -1,0 +1,63 @@
+import { sql, type CompiledQuery, type Kysely } from "kysely";
+import type { Database } from "../db";
+
+const ROW_ID = 1;
+
+export interface SyncState {
+  version: number;
+  payloadHash: string | null;
+}
+
+export function readSyncState(
+  db: Kysely<Database>,
+): Promise<SyncState | undefined> {
+  return db
+    .selectFrom("syncState")
+    .select(["version", "payloadHash"])
+    .where("id", "=", ROW_ID)
+    .executeTakeFirst();
+}
+
+export interface SyncRecord {
+  /** `null` when the writer covered a different dataset than the cron fetches. */
+  payloadHash: string | null;
+  changed: boolean;
+}
+
+export function recordSync(
+  db: Kysely<Database>,
+  { payloadHash, changed }: SyncRecord,
+) {
+  const now = sql<string>`datetime('now')`;
+
+  return db
+    .updateTable("syncState")
+    .set({
+      payloadHash,
+      syncedAt: now,
+      ...(changed ? { version: sql<number>`version + 1`, changedAt: now } : {}),
+    })
+    .where("id", "=", ROW_ID)
+    .returning("version");
+}
+
+/**
+ * Fingerprints a write batch by its SQL and bound parameters, so a payload that
+ * would produce byte-identical statements can skip the batch entirely rather
+ * than paying D1's one-row-per-statement floor for a no-op.
+ */
+export async function hashStatements(
+  queries: readonly CompiledQuery[],
+): Promise<string> {
+  const canonical = JSON.stringify(
+    queries.map((query) => [query.sql, query.parameters]),
+  );
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonical),
+  );
+
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/activity/upsert.test.ts
+++ b/src/activity/upsert.test.ts
@@ -3,7 +3,12 @@ import type { Kysely } from "kysely";
 import type { Database } from "@/db";
 import { createTestDb } from "@/test/db";
 import type { RepoActivity } from "@workspace/github";
-import { upsertRepo, upsertActivity } from "./upsert";
+import {
+  activityStatements,
+  upsertActivity,
+  upsertLanguageExtension,
+  upsertRepo,
+} from "./upsert";
 
 function makeRepo(overrides: Partial<RepoActivity> = {}): RepoActivity {
   return {
@@ -108,5 +113,99 @@ describe("upsert builders", () => {
       .executeTakeFirstOrThrow();
     expect(stored.primaryLanguageName).toBeNull();
     expect(stored.primaryLanguageColor).toBeNull();
+  });
+
+  it("writes nothing when the incoming row is identical", async () => {
+    const repo = makeRepo();
+    await upsertRepo(db, repo).execute();
+    await upsertActivity(db, repo).execute();
+
+    // `updated_at` defaults to `datetime('now')`, whose one-second resolution
+    // would hide a rewrite within the same second. A sentinel cannot.
+    await db
+      .updateTable("repos")
+      .set({ updatedAt: "1999-12-31 23:59:59" })
+      .execute();
+
+    const [repoResult] = await upsertRepo(db, repo).execute();
+    const [activityResult] = await upsertActivity(db, repo).execute();
+
+    expect(repoResult.numInsertedOrUpdatedRows).toBe(0n);
+    expect(activityResult.numInsertedOrUpdatedRows).toBe(0n);
+
+    const stored = await db
+      .selectFrom("repos")
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(stored.updatedAt).toBe("1999-12-31 23:59:59");
+  });
+
+  it("writes when a primary language appears or disappears", async () => {
+    await upsertRepo(db, makeRepo({ primaryLanguage: null })).execute();
+
+    const [added] = await upsertRepo(
+      db,
+      makeRepo({ primaryLanguage: { name: "Go", color: "#00ADD8" } }),
+    ).execute();
+    expect(added.numInsertedOrUpdatedRows).toBe(1n);
+
+    const [removed] = await upsertRepo(
+      db,
+      makeRepo({ primaryLanguage: null }),
+    ).execute();
+    expect(removed.numInsertedOrUpdatedRows).toBe(1n);
+
+    const stored = await db
+      .selectFrom("repos")
+      .selectAll()
+      .executeTakeFirstOrThrow();
+    expect(stored.primaryLanguageName).toBeNull();
+  });
+
+  it("writes a language extension only when it changes", async () => {
+    await upsertLanguageExtension(db, "TypeScript", ".ts").execute();
+
+    const [same] = await upsertLanguageExtension(
+      db,
+      "TypeScript",
+      ".ts",
+    ).execute();
+    expect(same.numInsertedOrUpdatedRows).toBe(0n);
+
+    const [changed] = await upsertLanguageExtension(
+      db,
+      "TypeScript",
+      ".tsx",
+    ).execute();
+    expect(changed.numInsertedOrUpdatedRows).toBe(1n);
+  });
+});
+
+describe("activityStatements", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it("orders statements by owner and name regardless of fetch order", () => {
+    const repos = [
+      makeRepo({ owner: "zed", name: "zed" }),
+      makeRepo({ owner: "bendrucker", name: "quibble" }),
+      makeRepo({ owner: "bendrucker", name: "cool-lib" }),
+    ];
+
+    const forward = activityStatements(db, repos);
+    const reversed = activityStatements(db, [...repos].reverse());
+
+    expect(forward.map((query) => query.parameters)).toEqual(
+      reversed.map((query) => query.parameters),
+    );
+    expect(forward).toHaveLength(repos.length * 2);
+    expect(forward[0].parameters).toContain("cool-lib");
   });
 });

--- a/src/activity/upsert.ts
+++ b/src/activity/upsert.ts
@@ -1,4 +1,4 @@
-import { sql, type Kysely } from "kysely";
+import { sql, type CompiledQuery, type Kysely } from "kysely";
 import type { Database } from "../db";
 import type { RepoActivity } from "@workspace/github";
 
@@ -16,14 +16,40 @@ export function upsertRepo(db: Kysely<Database>, repo: RepoActivity) {
       createdAt: repo.createdAt ? new Date(repo.createdAt).toISOString() : null,
     })
     .onConflict((oc) =>
-      oc.columns(["owner", "name"]).doUpdateSet((eb) => ({
-        description: eb.ref("excluded.description"),
-        url: eb.ref("excluded.url"),
-        primaryLanguageName: eb.ref("excluded.primaryLanguageName"),
-        primaryLanguageColor: eb.ref("excluded.primaryLanguageColor"),
-        stargazerCount: eb.ref("excluded.stargazerCount"),
-        updatedAt: sql`datetime('now')`,
-      })),
+      oc
+        .columns(["owner", "name"])
+        .doUpdateSet((eb) => ({
+          description: eb.ref("excluded.description"),
+          url: eb.ref("excluded.url"),
+          primaryLanguageName: eb.ref("excluded.primaryLanguageName"),
+          primaryLanguageColor: eb.ref("excluded.primaryLanguageColor"),
+          stargazerCount: eb.ref("excluded.stargazerCount"),
+          updatedAt: sql`datetime('now')`,
+        }))
+        // D1 bills a rewritten row even when every value is identical, and the
+        // hourly cron re-sends the same payload for most repos. `is not` rather
+        // than `!=` so a nullable column going to or from NULL still counts.
+        .where((eb) =>
+          eb.or([
+            eb("repos.description", "is not", eb.ref("excluded.description")),
+            eb("repos.url", "is not", eb.ref("excluded.url")),
+            eb(
+              "repos.primaryLanguageName",
+              "is not",
+              eb.ref("excluded.primaryLanguageName"),
+            ),
+            eb(
+              "repos.primaryLanguageColor",
+              "is not",
+              eb.ref("excluded.primaryLanguageColor"),
+            ),
+            eb(
+              "repos.stargazerCount",
+              "is not",
+              eb.ref("excluded.stargazerCount"),
+            ),
+          ]),
+        ),
     );
 }
 
@@ -46,14 +72,46 @@ export function upsertActivity(db: Kysely<Database>, repo: RepoActivity) {
       lastActivity,
     })
     .onConflict((oc) =>
-      oc.columns(["repoId", "year"]).doUpdateSet((eb) => ({
-        prCount: eb.ref("excluded.prCount"),
-        reviewCount: eb.ref("excluded.reviewCount"),
-        issueCount: eb.ref("excluded.issueCount"),
-        mergeCount: eb.ref("excluded.mergeCount"),
-        hasMergedPrs: eb.ref("excluded.hasMergedPrs"),
-        lastActivity: eb.ref("excluded.lastActivity"),
-      })),
+      oc
+        .columns(["repoId", "year"])
+        .doUpdateSet((eb) => ({
+          prCount: eb.ref("excluded.prCount"),
+          reviewCount: eb.ref("excluded.reviewCount"),
+          issueCount: eb.ref("excluded.issueCount"),
+          mergeCount: eb.ref("excluded.mergeCount"),
+          hasMergedPrs: eb.ref("excluded.hasMergedPrs"),
+          lastActivity: eb.ref("excluded.lastActivity"),
+        }))
+        .where((eb) =>
+          eb.or([
+            eb("repoActivity.prCount", "is not", eb.ref("excluded.prCount")),
+            eb(
+              "repoActivity.reviewCount",
+              "is not",
+              eb.ref("excluded.reviewCount"),
+            ),
+            eb(
+              "repoActivity.issueCount",
+              "is not",
+              eb.ref("excluded.issueCount"),
+            ),
+            eb(
+              "repoActivity.mergeCount",
+              "is not",
+              eb.ref("excluded.mergeCount"),
+            ),
+            eb(
+              "repoActivity.hasMergedPrs",
+              "is not",
+              eb.ref("excluded.hasMergedPrs"),
+            ),
+            eb(
+              "repoActivity.lastActivity",
+              "is not",
+              eb.ref("excluded.lastActivity"),
+            ),
+          ]),
+        ),
     );
 }
 
@@ -68,6 +126,32 @@ export function upsertLanguageExtension(
     .onConflict((oc) =>
       oc
         .column("name")
-        .doUpdateSet((eb) => ({ extension: eb.ref("excluded.extension") })),
+        .doUpdateSet((eb) => ({ extension: eb.ref("excluded.extension") }))
+        .where((eb) =>
+          eb(
+            "languageExtensions.extension",
+            "is not",
+            eb.ref("excluded.extension"),
+          ),
+        ),
     );
+}
+
+/**
+ * Every statement a fetch translates to, sorted so that two fetches carrying
+ * the same data compile identically no matter what order GitHub returned the
+ * repos in. `hashStatements` reads that as "nothing to write".
+ */
+export function activityStatements(
+  db: Kysely<Database>,
+  repos: RepoActivity[],
+): CompiledQuery[] {
+  return [...repos]
+    .sort(
+      (a, b) => a.owner.localeCompare(b.owner) || a.name.localeCompare(b.name),
+    )
+    .flatMap((repo) => [
+      upsertRepo(db, repo).compile(),
+      upsertActivity(db, repo).compile(),
+    ]);
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -31,10 +31,19 @@ export interface LanguageExtensionsTable {
   extension: string;
 }
 
+export interface SyncStateTable {
+  id: Generated<number>;
+  version: Generated<number>;
+  payloadHash: string | null;
+  changedAt: Generated<string>;
+  syncedAt: Generated<string>;
+}
+
 export interface Database {
   repos: ReposTable;
   repoActivity: RepoActivityTable;
   languageExtensions: LanguageExtensionsTable;
+  syncState: SyncStateTable;
 }
 
 export function createDb(d1: D1Database): Kysely<Database> {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,33 @@
-import type { MiddlewareHandler } from "astro";
+import type { APIContext, MiddlewareHandler } from "astro";
 import { sequence } from "astro:middleware";
-import { activityCachePolicy, isActivityPath } from "./middleware/cache";
-import { negotiate, PRODUCES } from "./middleware/negotiate";
+import { readSyncState } from "./activity/sync-state";
+import { getDb } from "./db";
+import {
+  activityCachePolicy,
+  activityETag,
+  etagMatches,
+  isActivityPath,
+} from "./middleware/cache";
+import { prefersMarkdown } from "./middleware/negotiate";
 import { MARKDOWN_CONTENT_TYPE, representationFor } from "./representations";
 
 const cache: MiddlewareHandler = async (context, next) => {
-  const response = await next();
   const { method } = context.request;
+  const conditional =
+    (method === "GET" || method === "HEAD") &&
+    !context.isPrerendered &&
+    isActivityPath(context.url.pathname);
+
+  if (conditional) {
+    const etag = await syncETag(context);
+    context.cache.set({ ...activityCachePolicy(new Date()), etag });
+
+    if (etagMatches(context.request.headers.get("If-None-Match"), etag)) {
+      return new Response(null, { status: 304, headers: varyHeaders(context) });
+    }
+  }
+
+  const response = await next();
   if (method !== "GET" && method !== "HEAD") return response;
   if (context.isPrerendered) return response;
 
@@ -15,15 +36,26 @@ const cache: MiddlewareHandler = async (context, next) => {
   // `Cache-Control`. Opt back out for responses that must not be cached.
   if (response.status !== 200 || response.headers.has("Cache-Control")) {
     context.cache.set(false);
-    return response;
-  }
-
-  if (isActivityPath(context.url.pathname)) {
-    context.cache.set(activityCachePolicy(new Date()));
   }
 
   return response;
 };
+
+async function syncETag(context: APIContext): Promise<string> {
+  const state = await readSyncState(await getDb());
+  const negotiable = representationFor(context.routePattern) !== undefined;
+
+  return activityETag(
+    state?.version ?? 0,
+    negotiable && prefersMarkdown(context.request) ? "md" : "html",
+  );
+}
+
+// A 304 answers before the markdown middleware runs, so it has to carry the
+// `Vary` that middleware would have added to the full response.
+function varyHeaders(context: APIContext): HeadersInit {
+  return representationFor(context.routePattern) ? { Vary: "Accept" } : {};
+}
 
 const markdown: MiddlewareHandler = async (context, next) => {
   const { request } = context;
@@ -36,8 +68,7 @@ const markdown: MiddlewareHandler = async (context, next) => {
     return next();
   }
 
-  const chosen = negotiate(request.headers.get("accept"), PRODUCES);
-  if (chosen === "text/markdown") {
+  if (prefersMarkdown(request)) {
     const md = await representation.render(context);
     if (md !== null) {
       return new Response(request.method === "HEAD" ? null : md, {

--- a/src/middleware/cache.test.ts
+++ b/src/middleware/cache.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { activityCachePolicy, activityMaxAge, isActivityPath } from "./cache";
+import {
+  activityCachePolicy,
+  activityETag,
+  activityMaxAge,
+  etagMatches,
+  isActivityPath,
+} from "./cache";
 
 describe("activityMaxAge", () => {
   it("expires at five past the next hour mid-hour", () => {
@@ -42,5 +48,36 @@ describe("activityCachePolicy", () => {
       maxAge: 2100,
       swr: 3600,
     });
+  });
+});
+
+describe("activityETag", () => {
+  it("separates the representations served at one URL", () => {
+    expect(activityETag(7, "html")).toBe('"7-html"');
+    expect(activityETag(7, "md")).toBe('"7-md"');
+  });
+});
+
+describe("etagMatches", () => {
+  const etag = activityETag(7, "html");
+
+  it("ignores a request with no validator", () => {
+    expect(etagMatches(null, etag)).toBe(false);
+    expect(etagMatches("", etag)).toBe(false);
+  });
+
+  it("matches the same version and representation", () => {
+    expect(etagMatches('"7-html"', etag)).toBe(true);
+    expect(etagMatches('"6-html"', etag)).toBe(false);
+    expect(etagMatches('"7-md"', etag)).toBe(false);
+  });
+
+  it("compares weakly", () => {
+    expect(etagMatches('W/"7-html"', etag)).toBe(true);
+  });
+
+  it("accepts any entry in a list, and the wildcard", () => {
+    expect(etagMatches('"6-html", "7-html"', etag)).toBe(true);
+    expect(etagMatches("*", etag)).toBe(true);
   });
 });

--- a/src/middleware/cache.ts
+++ b/src/middleware/cache.ts
@@ -1,9 +1,10 @@
 // Activity pages render from D1 that the github worker cron ("0 * * * *")
 // refreshes at the top of every hour. Their max-age expires just after the
-// next sync completes, so cached responses only bust when new data can
-// actually exist. Everything else changes only on deploy and is covered by
-// `routeRules` in astro.config.ts, and the Workers Cache key includes the
-// Worker version, so deploys invalidate it regardless of TTL.
+// next sync completes, which sets how often a cached response revalidates.
+// The ETag then decides whether that revalidation costs a re-render or a 304.
+// Everything else changes only on deploy and is covered by `routeRules` in
+// astro.config.ts, and the Workers Cache key includes the Worker version, so
+// deploys invalidate it regardless of TTL.
 const ACTIVITY_SYNC_BUFFER_SECONDS = 300;
 
 export interface CachePolicy {
@@ -17,6 +18,30 @@ export function isActivityPath(pathname: string): boolean {
 
 export function activityCachePolicy(now: Date): CachePolicy {
   return { maxAge: activityMaxAge(now), swr: 3600 };
+}
+
+/**
+ * `sync_state.version` moves only when the github cron actually changed a row,
+ * so it identifies the rendered dataset. The variant is part of the tag because
+ * `/activity/code` serves HTML or markdown at one URL, by `Accept`.
+ */
+export function activityETag(version: number, variant: "html" | "md"): string {
+  return `"${version}-${variant}"`;
+}
+
+export function etagMatches(ifNoneMatch: string | null, etag: string): boolean {
+  if (!ifNoneMatch) return false;
+
+  const header = ifNoneMatch.trim();
+  if (header === "*") return true;
+
+  const target = opaque(etag);
+  return header.split(",").some((tag) => opaque(tag.trim()) === target);
+}
+
+// `If-None-Match` compares weakly, so `W/"x"` and `"x"` are the same validator.
+function opaque(tag: string): string {
+  return tag.startsWith("W/") ? tag.slice(2) : tag;
 }
 
 export function activityMaxAge(now: Date): number {

--- a/src/middleware/negotiate.ts
+++ b/src/middleware/negotiate.ts
@@ -1,5 +1,9 @@
 export const PRODUCES = ["text/html", "text/markdown"] as const;
 
+export function prefersMarkdown(request: Request): boolean {
+  return negotiate(request.headers.get("accept"), PRODUCES) === "text/markdown";
+}
+
 type AcceptEntry = {
   type: string;
   subtype: string;

--- a/workers/github/main.ts
+++ b/workers/github/main.ts
@@ -2,7 +2,12 @@ import type { RepoActivity } from "@workspace/github";
 import { logger } from "@workspace/logger";
 import type { CompiledQuery } from "kysely";
 import { createDb } from "../../src/db";
-import { upsertRepo, upsertActivity } from "../../src/activity/upsert";
+import { activityStatements } from "../../src/activity/upsert";
+import {
+  hashStatements,
+  readSyncState,
+  recordSync,
+} from "../../src/activity/sync-state";
 import { fetchGitHubActivityWithConfig } from "../../src/services/github";
 
 type Env = Required<Cloudflare.Env> & {
@@ -21,23 +26,44 @@ async function upsertActivityToD1(
 ): Promise<void> {
   const db = createDb(d1);
 
-  const statements: D1PreparedStatement[] = [];
-  for (const repo of repos) {
-    statements.push(prepare(d1, upsertRepo(db, repo).compile()));
-    statements.push(prepare(d1, upsertActivity(db, repo).compile()));
+  const queries = activityStatements(db, repos);
+  const payloadHash = await hashStatements(queries);
+
+  const state = await readSyncState(db);
+  if (state?.payloadHash === payloadHash) {
+    logger.info(
+      { version: state.version, statements: queries.length },
+      "GitHub payload unchanged, skipped D1 write",
+    );
+    return;
   }
 
-  let totalResults = 0;
+  const statements = queries.map((query) => prepare(d1, query));
+
+  let changes = 0;
   for (let i = 0; i < statements.length; i += BATCH_SIZE) {
     const chunk = statements.slice(i, i + BATCH_SIZE);
     const results = await d1.batch(chunk);
-    totalResults += results.length;
+    changes += results.reduce(
+      (total, result) => total + result.meta.changes,
+      0,
+    );
   }
+
+  // A differing payload does not guarantee a differing database: dropping a
+  // repo from the fetch, or a change to an insert-only column like
+  // `created_at`, leaves every guarded statement a no-op. The version has to
+  // track the rows, since that is what the cached pages render.
+  const { version } = await recordSync(db, {
+    payloadHash,
+    changed: changes > 0,
+  }).executeTakeFirstOrThrow();
 
   logger.info(
     {
       statements: statements.length,
-      results: totalResults,
+      changes,
+      version,
     },
     "D1 upsert completed",
   );


### PR DESCRIPTION
The github cron wrote 416 rows/hr to D1 whether or not anything on GitHub
changed. It fetches current-year activity, 52 repos today, and issues two
unconditional `ON CONFLICT ... DO UPDATE` statements per repo, so identical
rows were rewritten hourly. `upsertRepo` also set `updated_at = datetime('now')`,
which guaranteed every row was dirty.

Measured `meta.rows_written` against production, re-running each statement with
unchanged values:

| statement | `changes` | `rows_written` |
| --- | --- | --- |
| `repos` upsert, before | 1 | 3 |
| `repo_activity` upsert, before | 1 | 5 |
| either, guarded and matching nothing | 0 | 1 |

`(3 + 5) x 52 = 416`. `repo_activity` costs more because `year` is a `STORED`
generated column derived from `last_activity`, so touching it marks all three
of its indexes. The `1` is D1's floor for attempting an insert, charged per
statement.

## Guards

All three upserts now carry a `WHERE` on the `DO UPDATE`, comparing with
`is not` so a nullable column crossing NULL still writes. `!=` would miss a
`primaryLanguage` appearing or disappearing. Guard columns mirror each
`doUpdateSet` minus `updated_at`. `created_at` is insert-only and stays out.

That takes the hourly floor to 104, and makes `repos.updated_at` mean "last
time this repo actually changed" instead of "last time the cron ran".

## `sync_state`

`max(repos.updated_at)` still isn't a dataset version. `repo_activity` has no
timestamp of its own and a repo's card aggregates both tables, so counts can
move without any `repos` column moving. And no per-row version can express a
removal: a repo renamed or made private drops out of the fetch, and the row
carrying the evidence is the one that's gone.

So the writer maintains an explicit version. Migration 0004 adds a one-row
table; the cron hashes the batch it's about to run, skips it outright on a
match, and otherwise bumps `version` only when a statement reported a change.

The hash covers the **compiled statements**, meaning SQL text plus bound
parameters, rather than a hand-listed projection of the fetched fields. That's
the literal question being asked ("would running this batch write anything?"),
and it can't drift out of sync with the upserts the way a parallel field list
would. A Kysely upgrade that reflows whitespace would invalidate it once, which
costs one extra write.

`activityStatements` sorts by owner/name, so the hash is blind to the order
GitHub returns repos in. The version bump stays separate from the hash anyway,
because a differing payload doesn't guarantee a differing database: a repo
dropping out of the fetch changes the hash while leaving every remaining
statement a no-op.

Stars participate in both. Leaving them out of the hash would mean star counts
never reach D1 at all. Leaving them out of only the version bump would serve
stale counts under a valid ETag. Either way it saves nothing, since the `repos`
guard compares `stargazer_count` regardless, so the churn they add to the
version is the honest cost of showing them.

## ETag

`/activity*` served on a cron-aligned TTL, a timer guessing when new data might
exist. That fallback was forced by #506: Workers Caching is scoped to the
owning Worker and entrypoint, so the cron can't purge tags set by `www`, and
there's no zone-level tag purge. Nothing here assumes otherwise.

The version becomes the ETag, read on cache miss or revalidation as a
single-row primary-key lookup. `If-None-Match` is answered with a 304 before
rendering, so expiry on an unchanged dataset costs one row read instead of a
full re-render per colo per route per hour. The TTL stays, demoted from
correctness mechanism to revalidation cadence.

The tag carries the negotiated representation (`"7-html"` / `"7-md"`) because
`/activity/code` serves HTML or markdown at one URL by `Accept`. A
version-only tag would 304 a markdown request against an HTML validator. The
304 also carries the `Vary: Accept` that the markdown middleware would have
added, since it answers before that middleware runs.

Version-in-URL doesn't work here: the HTML embedding the version is itself
cached and would advertise stale versions, and D1 only holds current data, so
old-version URLs would lie.

## Verification

Tests run the real migrations against in-memory SQLite. A repeat upsert of
identical data reports `numInsertedOrUpdatedRows === 0n` and leaves a sentinel
`updated_at` untouched. It's a sentinel rather than a timestamp comparison
because `datetime('now')` has one-second resolution and would hide a
same-second rewrite. A `primaryLanguage` going from null to a value and back
still writes both ways.

Conditional requests, against the dev server:

```
"0-html" on HTML                  -> 304
"0-md"   on Accept: text/markdown -> 304
"0-html" on Accept: text/markdown -> 200
"0-md"   on HTML                  -> 200
W/"9-html" (stale)                -> 200
```

I could not measure `rows_written` locally. The wrangler CLI returns
`{"changes":null,"rows_written":null}` against local D1. The production numbers
above predate this branch. The post-deploy check is confirming a guarded no-op
reports `rows_written: 1` with `changes: 0`, and watching D1 metrics fall from
416/hr.

## Before merging

**Migration 0004 has to be applied to remote D1 before this deploys.** No
workflow applies migrations, since there's no D1 step in `.github/workflows/`,
so it's manual. `/activity*` will 500 on a missing table if the workers ship
first.

```
npx wrangler d1 migrations apply bendrucker-activity --remote
```

## Not done

**Batching each table into one multi-row `INSERT ... VALUES (...), (...)`.**
The guarded floor is 1 row per *statement*, so 104 statements still cost 104
rows. One statement per table might cost ~2. If that holds it beats the hash
short-circuit, because it wins on hours when data did change rather than only
on quiet ones. It's unverified, and local D1 reports no `meta`, so measuring it
means writing to production.

**Reconciling deleted repos.** A repo renamed, deleted, or made private still
leaves a ghost row forever, and a rename mints a new one since the conflict key
is `(owner, name)`. Pre-existing and out of scope. But `sync_state` is what
makes it expressible, since the pass would run in the writer and bump the
version like any other change.

**Replacing the Astro Actions.** `ActivityTimeline.vue` fires three uncacheable
POST actions on mount and three more per filter change, and middleware skips
non-GET entirely. That's the dominant *read* cost, and one full-dataset GET
under this same ETag policy with client-side filtering would delete all three.
Independent of everything here now that `sync_state` exists.
