### PR TITLE
ci: apply D1 migrations before deploying workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,42 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  migrate:
+    name: migrations
+    # Matches the cloudflare job so the two never disagree: a job skipped by its
+    # own condition also skips everything that needs it.
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: "☁️ Checkout repository"
+        uses: actions/checkout@v7.0.1
+
+      - name: "📦 Setup Node.js"
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: "📦 Install dependencies"
+        run: npm ci
+
+      # There is one D1 database, so a PR run would migrate production before
+      # review. Pull requests only upload preview versions, which take no
+      # traffic, so they never need the schema.
+      - name: "🗃️ Apply D1 migrations"
+        if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        uses: cloudflare/wrangler-action@v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply bendrucker-activity --remote
+
   cloudflare:
     name: ${{ matrix.name }}
+    needs: migrate
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)) && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
`migrations/` has always been applied to remote D1 by hand, and #585 nearly made that visible: it added `0004_sync_state.sql` alongside worker code that reads `sync_state`. Merging it deploys three workers against a database without the table. The www middleware reads `sync_state` before rendering, so `/activity*` would have 500'd, and the github cron would have thrown on its next hourly tick. Nothing in `.github/workflows/` applied the migration.

A `migrate` job now runs `wrangler d1 migrations apply bendrucker-activity --remote` from the root config (`migrations_dir = "migrations"`), and the `cloudflare` matrix `needs` it. Migrations land once, before any worker that depends on them deploys, instead of three times concurrently from inside the matrix.

## Why the apply is push-only

There is one D1 database. No preview, no branch copy. A `pull_request` run that applied migrations would mutate production data before anyone reviewed the migration. PR runs already avoid needing the schema: they do `versions upload`, which publishes a preview version that takes no traffic. So the apply step carries `github.event_name == 'push' && github.ref_name == github.event.repository.default_branch`, and migrations reach D1 only after merge.

## Job shape

The trap here is that a job skipped by its own `if:` skips every job that `needs:` it. If `migrate` were push-only at the job level, the three `cloudflare` matrix jobs would stop running on PRs entirely.

Two shapes work. I took the one where `migrate` always runs and only the apply step is conditional, rather than putting the `if:` on the job and adding a `needs.migrate.result` tolerance to `cloudflare`. The deciding factor is what happens when a migration fails. With this shape the blocking behavior is free: `cloudflare`'s existing `if:` has no status function, so GitHub ANDs an implicit `success()`, and a failed `migrate` skips the deploy. The alternative shape requires rewriting that condition to accept `skipped`, and every phrasing that tolerates `skipped` has to be written carefully enough not to also tolerate `failure`. Getting that subtly wrong deploys workers over a failed migration, which is the exact outcome this PR exists to prevent.

`migrate` carries the same `if:` as `cloudflare` rather than none at all, so the two never disagree about whether to run. Wherever `cloudflare` skips (dependabot, `workflow_dispatch`), `migrate` skips with it.

The cost is a job on every PR run that checks out, installs, and skips its only real step. Installing is what makes the apply use the lockfile-pinned wrangler rather than whatever `wrangler@latest` resolves to on the day a migration ships, which seemed worth ~40s of PR time given the step writes to production.

## Verification

Verified:

- The PR scenario, on this PR's own [Deploy run](https://github.com/bendrucker/bendrucker.me/actions/runs/30863944145). `migrations` ran with `🗃️ Apply D1 migrations` skipped, and `www`, `github`, `strava`, and `lighthouse` all ran and succeeded downstream of it. The `needs: migrate` edge does not strand PR deploys.
- `actionlint` reports the same 5 pre-existing `SC2086` shellcheck infos as on `main`. No new findings.
- YAML parses. `cloudflare` needs `migrate`, the two job conditions are byte-identical, the apply step's condition is the push-to-default one, and the job has `contents: read` and `timeout-minutes: 10`.
- The apply auto-confirms in CI. In wrangler 4.118.0, `d1 migrations apply` calls `confirm()` with no options, so `fallbackValue` defaults to `true`, and `confirm()` returns that fallback whenever `isNonInteractiveOrCI()` holds, which it does on Actions. The command's own epilogue documents the behavior: "When running the apply command in a CI/CD environment or another non-interactive command line, the confirmation step will be skipped." The command's arg list defines `database`, `local`, `remote`, `preview`, and `persist-to`, so `--remote` is the whole invocation.
- `cloudflare/wrangler-action@v4.0.0` installs wrangler when none is present, and prefers a pre-installed version when the workflow supplies one, which `npm ci` does here.

Still unproven until this runs on a real push to `main`:

- That the apply succeeds against remote D1. The apply step has never executed. The API token's permissions on D1 are untested, and if it only carries Workers Scripts edit, the first push to `main` after this merges fails in `migrate` and blocks the deploy. Safe failure mode, noisy one.
- That `wrangler d1 migrations apply` is happy loading the root `wrangler.toml` in a checkout with no `dist/` built. Nothing bundles for this command and I found no directory existence check on `[assets]` in the config path, though the PR run skipped the step before it could load anything.
- That a failed migration actually blocks the deploy. Nothing failed in the run above. My claim that a `needs` job with a non-status `if:` gets an implicit `success()` rests on GitHub's documentation of it.

Deliberately did not run any `wrangler ... --remote` command while preparing this.
