### PR TITLE
build: register Prettier plugins

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
+  "tailwindStylesheet": "./src/styles/global.css",
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": {
+        "parser": "astro"
+      }
+    }
+  ]
+}

--- a/src/components/BackToTopButton.astro
+++ b/src/components/BackToTopButton.astro
@@ -59,7 +59,7 @@ import IconArrowNarrowUp from "@/assets/icons/IconArrowNarrowUp.svg";
 
       progressIndicator.style.setProperty(
         "background-image",
-        `conic-gradient(var(--accent), var(--accent) ${scrollPercent}%, transparent ${scrollPercent}%)`
+        `conic-gradient(var(--accent), var(--accent) ${scrollPercent}%, transparent ${scrollPercent}%)`,
       );
 
       const isVisible = scrollTop / scrollTotal > 0.3;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,9 @@ export interface Props {
 }
 
 const { noMarginTop = false, sourcePath } = Astro.props;
-const sourceUrl = sourcePath ? `${SITE.viewSource.url}${sourcePath}` : undefined;
+const sourceUrl = sourcePath
+  ? `${SITE.viewSource.url}${sourcePath}`
+  : undefined;
 ---
 
 <footer class:list={["page-column w-full", { "mt-auto": !noMarginTop }]}>
@@ -20,22 +22,24 @@ const sourceUrl = sourcePath ? `${SITE.viewSource.url}${sourcePath}` : undefined
     class="flex flex-col-reverse items-center gap-y-1 py-3 sm:flex-row sm:flex-wrap sm:justify-between sm:gap-x-3"
   >
     <div
-      class="flex items-center gap-1.5 whitespace-nowrap text-xs text-foreground/50"
+      class="flex items-center gap-1.5 text-xs whitespace-nowrap text-foreground/50"
     >
       <span>&#169; {currentYear} Ben Drucker</span>
-      {sourceUrl && (
-        <>
-          <span aria-hidden="true">&middot;</span>
-          <a
-            href={sourceUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-accent"
-          >
-            {SITE.viewSource.text}
-          </a>
-        </>
-      )}
+      {
+        sourceUrl && (
+          <>
+            <span aria-hidden="true">&middot;</span>
+            <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="hover:text-accent"
+            >
+              {SITE.viewSource.text}
+            </a>
+          </>
+        )
+      }
     </div>
     <Socials centered />
   </div>

--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -10,7 +10,7 @@ const URL = Astro.url;
     <div class="flex flex-none flex-col items-center justify-center gap-1 md:items-start">
       <span class="italic">Share this post on:</span>
       <div class="text-center">
-        {SHARE_LINKS.map(social => (
+        {SHARE_LINKS.map((social) => (
           <LinkButton
             href={`${social.href + URL}`}
             class="scale-90 p-2 hover:rotate-6 sm:p-1"

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -11,7 +11,7 @@ const { centered = false } = Astro.props;
 
 <div class:list={["flex-wrap justify-center gap-0.5", { flex: centered }]}>
   {
-    SOCIALS.map(social => (
+    SOCIALS.map((social) => (
       <LinkButton
         href={social.href}
         class="p-1 text-foreground/50 hover:rotate-6"

--- a/src/components/activity/ActivityTimeline.vue
+++ b/src/components/activity/ActivityTimeline.vue
@@ -151,7 +151,7 @@ onMounted(() => {
   <div ref="rootRef" class="relative space-y-4">
     <div
       ref="headerRef"
-      class="sticky top-0 z-10 bg-background space-y-3 pt-3 -mt-3 pb-3 after:content-[''] after:absolute after:left-0 after:right-0 after:top-full after:h-6 after:bg-gradient-to-b after:from-background after:to-transparent after:pointer-events-none"
+      class="sticky top-0 z-10 -mt-3 space-y-3 bg-background pt-3 pb-3 after:pointer-events-none after:absolute after:top-full after:right-0 after:left-0 after:h-6 after:bg-gradient-to-b after:from-background after:to-transparent after:content-['']"
     >
       <FilterControls
         :filters="state.filters"
@@ -179,7 +179,7 @@ onMounted(() => {
 
     <p
       v-if="!state.loading && state.repos.length === 0"
-      class="text-center text-muted py-8"
+      class="py-8 text-center text-muted"
     >
       No activity data available.
     </p>

--- a/src/components/activity/FilterControls.vue
+++ b/src/components/activity/FilterControls.vue
@@ -46,10 +46,10 @@ function resetFilters() {
       :aria-pressed="(filters.owner === 'all').toString()"
       :class="
         filters.owner === 'all'
-          ? 'bg-accent text-background border-accent'
+          ? 'border-accent bg-accent text-background'
           : 'border-border text-foreground hover:border-accent'
       "
-      class="flex items-center h-8 px-3 rounded-full text-sm font-medium border transition-colors"
+      class="flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors"
       @click="setOwner('all')"
     >
       All
@@ -58,15 +58,15 @@ function resetFilters() {
       :aria-pressed="(filters.owner === 'personal').toString()"
       :class="
         filters.owner === 'personal'
-          ? 'bg-accent text-background border-accent'
+          ? 'border-accent bg-accent text-background'
           : 'border-border text-foreground hover:border-accent'
       "
-      class="flex items-center gap-1.5 h-8 px-3 rounded-full text-sm font-medium border transition-colors"
+      class="flex h-8 items-center gap-1.5 rounded-full border px-3 text-sm font-medium transition-colors"
       title="Personal repositories"
       @click="setOwner('personal')"
     >
       <svg
-        class="w-3.5 h-3.5"
+        class="h-3.5 w-3.5"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         fill="none"
@@ -84,15 +84,15 @@ function resetFilters() {
       :aria-pressed="(filters.owner === 'external').toString()"
       :class="
         filters.owner === 'external'
-          ? 'bg-accent text-background border-accent'
+          ? 'border-accent bg-accent text-background'
           : 'border-border text-foreground hover:border-accent'
       "
-      class="flex items-center gap-1.5 h-8 px-3 rounded-full text-sm font-medium border transition-colors"
+      class="flex h-8 items-center gap-1.5 rounded-full border px-3 text-sm font-medium transition-colors"
       title="External / organization repositories"
       @click="setOwner('external')"
     >
       <svg
-        class="w-3.5 h-3.5"
+        class="h-3.5 w-3.5"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         fill="none"
@@ -111,7 +111,7 @@ function resetFilters() {
     <span class="ml-auto flex items-center gap-1.5 text-xs text-foreground/50">
       <button
         v-if="hasActiveFilter"
-        class="text-foreground/40 hover:text-foreground transition-colors"
+        class="text-foreground/40 transition-colors hover:text-foreground"
         aria-label="Reset filters"
         @click="resetFilters"
       >
@@ -124,7 +124,7 @@ function resetFilters() {
   <div class="flex items-center gap-2">
     <div class="relative flex-1">
       <svg
-        class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-foreground/40 pointer-events-none"
+        class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-foreground/40"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         fill="none"
@@ -141,7 +141,7 @@ function resetFilters() {
         :value="filters.search"
         placeholder="Search"
         aria-label="Search repositories"
-        class="w-full pl-9 pr-3 py-2 text-sm border border-border rounded-md bg-background text-foreground placeholder:text-foreground/40 focus:outline-none focus:border-accent"
+        class="w-full rounded-md border border-border bg-background py-2 pr-3 pl-9 text-sm text-foreground placeholder:text-foreground/40 focus:border-accent focus:outline-none"
         @input="
           emit('update:filters', {
             search: ($event.target as HTMLInputElement).value,
@@ -152,7 +152,7 @@ function resetFilters() {
     </div>
     <div class="relative flex-shrink-0">
       <svg
-        class="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-foreground/40 pointer-events-none"
+        class="pointer-events-none absolute top-1/2 left-2 h-3.5 w-3.5 -translate-y-1/2 text-foreground/40"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
         fill="none"
@@ -170,7 +170,7 @@ function resetFilters() {
       <select
         :value="filters.sort"
         aria-label="Sort order"
-        class="h-9 pl-7 pr-6 text-sm border border-border rounded-md bg-background text-foreground/70 focus:outline-none focus:border-accent appearance-none cursor-pointer"
+        class="h-9 cursor-pointer appearance-none rounded-md border border-border bg-background pr-6 pl-7 text-sm text-foreground/70 focus:border-accent focus:outline-none"
         @change="
           emit('update:filters', {
             sort: ($event.target as HTMLSelectElement)

--- a/src/components/activity/LanguageBar.vue
+++ b/src/components/activity/LanguageBar.vue
@@ -111,12 +111,12 @@ function toggleChips() {
 
 <template>
   <div v-if="languages.length > 0">
-    <div class="flex h-6 rounded-full overflow-hidden">
+    <div class="flex h-6 overflow-hidden rounded-full">
       <button
         v-for="seg in primarySegments"
         :key="seg.name"
         :class="[
-          'h-full overflow-hidden flex items-center justify-center hover:opacity-80',
+          'flex h-full items-center justify-center overflow-hidden hover:opacity-80',
           selectedLanguage && selectedLanguage !== seg.name ? 'opacity-30' : '',
         ]"
         :style="{
@@ -130,7 +130,7 @@ function toggleChips() {
       >
         <span
           v-if="seg.pct >= 5"
-          class="text-[9px] font-medium truncate px-1 pointer-events-none"
+          class="pointer-events-none truncate px-1 text-[9px] font-medium"
           :style="{ color: seg.textColor }"
         >
           {{ seg.short }}
@@ -145,7 +145,7 @@ function toggleChips() {
         <HoverCardTrigger as-child>
           <button
             :class="[
-              'h-full overflow-hidden flex items-center justify-center hover:opacity-80',
+              'flex h-full items-center justify-center overflow-hidden hover:opacity-80',
               selectedLanguage && !isOverflowSelected ? 'opacity-30' : '',
             ]"
             :style="{
@@ -158,7 +158,7 @@ function toggleChips() {
           >
             <span
               v-if="overflowPct >= 5"
-              class="text-[9px] font-medium truncate px-1 pointer-events-none text-foreground/60"
+              class="pointer-events-none truncate px-1 text-[9px] font-medium text-foreground/60"
             >
               ...
             </span>
@@ -170,24 +170,24 @@ function toggleChips() {
             side="top"
             align="end"
             :side-offset="4"
-            class="bg-background border border-border rounded-lg shadow-lg p-1 z-10"
+            class="z-10 rounded-lg border border-border bg-background p-1 shadow-lg"
           >
             <button
               v-for="lang in overflowLangs.slice(0, 8)"
               :key="lang.name"
-              class="flex items-center gap-2 text-xs whitespace-nowrap py-1 px-1.5 rounded hover:bg-muted/20 w-full text-left"
+              class="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-xs whitespace-nowrap hover:bg-muted/20"
               @click="toggle(lang.name)"
             >
               <span
-                class="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+                class="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
                 :style="{ backgroundColor: lang.color }"
               />
               <span class="text-foreground">{{ lang.name }}</span>
-              <span class="text-muted ml-auto pl-3">{{ lang.count }}</span>
+              <span class="ml-auto pl-3 text-muted">{{ lang.count }}</span>
             </button>
             <div
               v-if="overflowLangs.length > 8"
-              class="text-xs text-muted py-0.5 px-1.5"
+              class="px-1.5 py-0.5 text-xs text-muted"
             >
               +{{ overflowLangs.length - 8 }} more
             </div>
@@ -206,7 +206,7 @@ function toggleChips() {
             v-for="seg in segments"
             :key="seg.name"
             :class="[
-              'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border border-border hover:opacity-80',
+              'inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-xs hover:opacity-80',
               selectedLanguage && selectedLanguage !== seg.name
                 ? 'opacity-30'
                 : '',
@@ -215,7 +215,7 @@ function toggleChips() {
             @click="toggle(seg.name)"
           >
             <span
-              class="inline-block w-2 h-2 rounded-full"
+              class="inline-block h-2 w-2 rounded-full"
               :style="{ backgroundColor: seg.color }"
             />
             {{ seg.short }}

--- a/src/components/activity/LoadingPulse.vue
+++ b/src/components/activity/LoadingPulse.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="flex items-center justify-center gap-3 py-6">
     <span
-      class="w-10 h-3 rounded-md bg-foreground/20 animate-pulse"
+      class="h-3 w-10 animate-pulse rounded-md bg-foreground/20"
       style="animation-delay: 0ms"
     />
     <span
-      class="w-10 h-3 rounded-md bg-foreground/20 animate-pulse"
+      class="h-3 w-10 animate-pulse rounded-md bg-foreground/20"
       style="animation-delay: 150ms"
     />
     <span
-      class="w-10 h-3 rounded-md bg-foreground/20 animate-pulse"
+      class="h-3 w-10 animate-pulse rounded-md bg-foreground/20"
       style="animation-delay: 300ms"
     />
   </div>

--- a/src/components/activity/RepoCard.vue
+++ b/src/components/activity/RepoCard.vue
@@ -93,24 +93,24 @@ function handleKeydown(e: KeyboardEvent) {
 
 <template>
   <div
-    class="group/card border border-border rounded-lg p-4 sm:p-6 bg-background focus-within:ring-1 focus-within:ring-accent"
+    class="group/card rounded-lg border border-border bg-background p-4 focus-within:ring-1 focus-within:ring-accent sm:p-6"
     tabindex="0"
     @keydown="handleKeydown"
   >
     <div
-      class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-3"
+      class="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
     >
-      <div class="flex-1 min-w-0">
-        <div class="flex flex-wrap items-center gap-2 mb-1">
+      <div class="min-w-0 flex-1">
+        <div class="mb-1 flex flex-wrap items-center gap-2">
           <h3 class="text-lg font-semibold">
             <a
               :href="repo.url"
               target="_blank"
               rel="noopener noreferrer"
-              class="text-foreground hover:text-accent focus:text-accent focus:outline-none focus:underline transition-colors"
+              class="text-foreground transition-colors hover:text-accent focus:text-accent focus:underline focus:outline-none"
             >
               <template v-if="isExternal">
-                <span class="text-foreground/60 font-normal"
+                <span class="font-normal text-foreground/60"
                   >{{ repo.owner }}/</span
                 >{{ repo.name }}
               </template>
@@ -119,7 +119,7 @@ function handleKeydown(e: KeyboardEvent) {
           </h3>
           <span
             v-if="repo.primaryLanguage"
-            class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium border border-border"
+            class="inline-flex items-center rounded-full border border-border px-2 py-1 text-xs font-medium"
             :style="{
               backgroundColor: repo.primaryLanguage.color + '20',
               color: repo.primaryLanguage.color,
@@ -129,13 +129,13 @@ function handleKeydown(e: KeyboardEvent) {
           </span>
           <span
             v-if="isNew"
-            class="inline-flex items-center px-2 py-1 rounded-full text-xs font-bold border border-green-500/30 bg-green-500/20 text-green-600"
+            class="inline-flex items-center rounded-full border border-green-500/30 bg-green-500/20 px-2 py-1 text-xs font-bold text-green-600"
             :title="createdTitle"
           >
             New!
           </span>
         </div>
-        <p class="text-foreground text-sm mb-3 line-clamp-2">
+        <p class="mb-3 line-clamp-2 text-sm text-foreground">
           {{ repo.description }}
         </p>
         <div
@@ -146,11 +146,11 @@ function handleKeydown(e: KeyboardEvent) {
             :href="getGitHubSearchUrl('pr')"
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center gap-1 hover:text-accent focus:text-accent focus:outline-none focus:underline transition-colors"
+            class="flex items-center gap-1 transition-colors hover:text-accent focus:text-accent focus:underline focus:outline-none"
             title="Pull requests authored"
           >
             <svg
-              class="w-4 h-4 flex-shrink-0"
+              class="h-4 w-4 flex-shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="none"
@@ -173,11 +173,11 @@ function handleKeydown(e: KeyboardEvent) {
             :href="getGitHubSearchUrl('review')"
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center gap-1 hover:text-accent focus:text-accent focus:outline-none focus:underline transition-colors"
+            class="flex items-center gap-1 transition-colors hover:text-accent focus:text-accent focus:underline focus:outline-none"
             title="Pull request reviews submitted"
           >
             <svg
-              class="w-4 h-4 flex-shrink-0"
+              class="h-4 w-4 flex-shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="none"
@@ -200,11 +200,11 @@ function handleKeydown(e: KeyboardEvent) {
             :href="getGitHubSearchUrl('merge')"
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center gap-1 hover:text-accent focus:text-accent focus:outline-none focus:underline transition-colors"
+            class="flex items-center gap-1 transition-colors hover:text-accent focus:text-accent focus:underline focus:outline-none"
             title="Pull requests merged"
           >
             <svg
-              class="w-4 h-4 flex-shrink-0"
+              class="h-4 w-4 flex-shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="none"
@@ -226,11 +226,11 @@ function handleKeydown(e: KeyboardEvent) {
             :href="getGitHubSearchUrl('issue')"
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center gap-1 hover:text-accent focus:text-accent focus:outline-none focus:underline transition-colors"
+            class="flex items-center gap-1 transition-colors hover:text-accent focus:text-accent focus:underline focus:outline-none"
             title="Issues opened or commented"
           >
             <svg
-              class="w-4 h-4 flex-shrink-0"
+              class="h-4 w-4 flex-shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="none"
@@ -249,11 +249,11 @@ function handleKeydown(e: KeyboardEvent) {
             :href="`${repo.url}/stargazers`"
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center gap-1 hover:text-accent focus:text-accent focus:outline-none focus:underline transition-colors"
+            class="flex items-center gap-1 transition-colors hover:text-accent focus:text-accent focus:underline focus:outline-none"
             title="GitHub stars"
           >
             <svg
-              class="w-4 h-4 flex-shrink-0"
+              class="h-4 w-4 flex-shrink-0"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="none"
@@ -270,15 +270,15 @@ function handleKeydown(e: KeyboardEvent) {
           </a>
         </div>
       </div>
-      <div class="text-sm text-foreground/60 flex-shrink-0 sm:text-right">
+      <div class="flex-shrink-0 text-sm text-foreground/60 sm:text-right">
         <time :datetime="lastActivityDate.toISOString()" :title="fullDate">
           {{ relativeDate }}
         </time>
         <div
-          class="hidden group-focus-within/card:flex items-center gap-1 mt-1 text-foreground/30 text-xs justify-end"
+          class="mt-1 hidden items-center justify-end gap-1 text-xs text-foreground/30 group-focus-within/card:flex"
         >
           <kbd
-            class="px-1 py-0.5 rounded border border-border bg-muted/50 text-[10px] font-mono leading-none"
+            class="rounded border border-border bg-muted/50 px-1 py-0.5 font-mono text-[10px] leading-none"
           >
             {{ isMac ? "\u2318O" : "Ctrl+O" }}
           </kbd>

--- a/src/components/activity/TimelineRail.vue
+++ b/src/components/activity/TimelineRail.vue
@@ -54,15 +54,15 @@ const hasNewerYears = computed(() => {
 <template>
   <nav
     v-if="years.length > 0"
-    class="hidden lg:flex absolute -right-16 top-0 h-full"
+    class="absolute top-0 -right-16 hidden h-full lg:flex"
     aria-label="Year navigation"
   >
     <div
-      class="sticky top-1/2 -translate-y-1/2 flex flex-col items-end gap-1 h-fit"
+      class="sticky top-1/2 flex h-fit -translate-y-1/2 flex-col items-end gap-1"
     >
       <button
         v-if="hasNewerYears"
-        class="text-sm text-foreground/20 hover:text-foreground/40 transition-colors px-1.5"
+        class="px-1.5 text-sm text-foreground/20 transition-colors hover:text-foreground/40"
         aria-label="Show all years"
         @click="expanded = true"
       >
@@ -71,10 +71,10 @@ const hasNewerYears = computed(() => {
       <template v-for="y in visibleYears" :key="y.year">
         <button
           v-if="loadedYears.has(y.year)"
-          class="text-sm tabular-nums transition-colors px-1.5 py-0.5 rounded"
+          class="rounded px-1.5 py-0.5 text-sm tabular-nums transition-colors"
           :class="
             currentYear === y.year
-              ? 'text-accent font-semibold'
+              ? 'font-semibold text-accent'
               : 'text-foreground/30 hover:text-foreground/60'
           "
           @click="emit('navigate', y.year)"
@@ -84,10 +84,10 @@ const hasNewerYears = computed(() => {
         <a
           v-else
           :href="`/activity/code/${y.year}`"
-          class="text-sm tabular-nums transition-colors px-1.5 py-0.5 rounded"
+          class="rounded px-1.5 py-0.5 text-sm tabular-nums transition-colors"
           :class="
             currentYear === y.year
-              ? 'text-accent font-semibold'
+              ? 'font-semibold text-accent'
               : 'text-foreground/30 hover:text-foreground/60'
           "
         >
@@ -96,7 +96,7 @@ const hasNewerYears = computed(() => {
       </template>
       <button
         v-if="hasOlderYears"
-        class="text-sm text-foreground/20 hover:text-foreground/40 transition-colors px-1.5"
+        class="px-1.5 text-sm text-foreground/20 transition-colors hover:text-foreground/40"
         aria-label="Show all years"
         @click="expanded = true"
       >

--- a/src/components/activity/YearActivity.vue
+++ b/src/components/activity/YearActivity.vue
@@ -184,7 +184,7 @@ onMounted(() => {
       <span v-else />
       <a
         href="/activity/code"
-        class="text-foreground/60 hover:text-accent transition-colors"
+        class="text-foreground/60 transition-colors hover:text-accent"
       >
         View in timeline
       </a>
@@ -199,7 +199,7 @@ onMounted(() => {
     </nav>
 
     <div
-      class="sticky top-0 z-10 bg-background space-y-3 pt-3 -mt-3 pb-3 after:content-[''] after:absolute after:left-0 after:right-0 after:top-full after:h-6 after:bg-gradient-to-b after:from-background after:to-transparent after:pointer-events-none"
+      class="sticky top-0 z-10 -mt-3 space-y-3 bg-background pt-3 pb-3 after:pointer-events-none after:absolute after:top-full after:right-0 after:left-0 after:h-6 after:bg-gradient-to-b after:from-background after:to-transparent after:content-['']"
     >
       <FilterControls
         :filters="state.filters"
@@ -228,19 +228,19 @@ onMounted(() => {
 
     <p
       v-if="!state.loading && state.repos.length === 0"
-      class="text-center text-muted py-8"
+      class="py-8 text-center text-muted"
     >
       No activity data for {{ year }}.
     </p>
 
     <nav
-      class="flex items-center justify-between text-sm pt-4 border-t border-border"
+      class="flex items-center justify-between border-t border-border pt-4 text-sm"
       aria-label="Year navigation"
     >
       <a
         v-if="prevYear"
         :href="`/activity/code/${prevYear}`"
-        class="text-accent hover:underline flex-shrink-0"
+        class="flex-shrink-0 text-accent hover:underline"
       >
         &larr; {{ prevYear }}
       </a>
@@ -254,9 +254,9 @@ onMounted(() => {
           :key="y.year"
           :href="`/activity/code/${y.year}`"
           :class="[
-            'px-2 py-1 rounded transition-colors',
+            'rounded px-2 py-1 transition-colors',
             y.year === year
-              ? 'bg-accent text-background font-medium'
+              ? 'bg-accent font-medium text-background'
               : 'text-foreground/60 hover:text-accent',
           ]"
           :aria-current="y.year === year ? 'page' : undefined"
@@ -271,7 +271,7 @@ onMounted(() => {
       <a
         v-if="nextYear"
         :href="`/activity/code/${nextYear}`"
-        class="text-accent hover:underline flex-shrink-0"
+        class="flex-shrink-0 text-accent hover:underline"
       >
         {{ nextYear }} &rarr;
       </a>

--- a/src/components/activity/YearDivider.vue
+++ b/src/components/activity/YearDivider.vue
@@ -10,6 +10,6 @@ defineProps<{
     class="sticky z-10 border-b border-border bg-background"
     :style="{ top: 'var(--header-height, 8.5rem)' }"
   >
-    <h2 class="text-2xl font-bold text-accent py-3">{{ year }}</h2>
+    <h2 class="py-3 text-2xl font-bold text-accent">{{ year }}</h2>
   </div>
 </template>

--- a/src/components/cycling/HighlightCard.vue
+++ b/src/components/cycling/HighlightCard.vue
@@ -84,7 +84,7 @@ const totals = computed(() => {
 
 <template>
   <article
-    class="flex flex-col border border-border rounded-lg overflow-hidden bg-background"
+    class="flex flex-col overflow-hidden rounded-lg border border-border bg-background"
     :aria-label="`${ride.name}, ${started.full}`"
   >
     <div

--- a/src/components/cycling/MonthRail.vue
+++ b/src/components/cycling/MonthRail.vue
@@ -66,7 +66,7 @@ const yearGroups = computed(() => {
               class="w-full px-2 py-1 text-right text-[11px] leading-4 transition-colors"
               :class="
                 month.key === activeKey
-                  ? 'text-accent font-bold'
+                  ? 'font-bold text-accent'
                   : 'text-foreground/70 hover:text-foreground'
               "
               :aria-current="month.key === activeKey ? 'location' : undefined"

--- a/src/components/cycling/PhotoLightbox.vue
+++ b/src/components/cycling/PhotoLightbox.vue
@@ -145,7 +145,7 @@ function onKeydown(event: KeyboardEvent) {
               {{ photo?.alt }}
             </span>
           </p>
-          <p class="min-w-0 max-w-[36ch] truncate text-foreground/80">
+          <p class="max-w-[36ch] min-w-0 truncate text-foreground/80">
             {{ rideName }}
           </p>
           <div class="ml-auto flex items-center gap-3">

--- a/src/components/cycling/RideCard.vue
+++ b/src/components/cycling/RideCard.vue
@@ -50,14 +50,14 @@ const metaLine = computed(() => {
 
 <template>
   <article
-    class="grid grid-cols-1 border border-border rounded-lg overflow-hidden bg-background"
+    class="grid grid-cols-1 overflow-hidden rounded-lg border border-border bg-background"
     :class="hasRoute ? 'sm:grid-cols-[var(--map-width)_1fr]' : ''"
     :style="{ '--map-width': `${mapWidth}px` }"
     :aria-label="`${ride.name}, ${started.full}`"
   >
     <div
       v-if="hasRoute"
-      class="flex items-center justify-center border-b border-border sm:border-b-0 sm:border-r"
+      class="flex items-center justify-center border-b border-border sm:border-r sm:border-b-0"
     >
       <RouteMap
         :coordinates="ride.route"
@@ -71,7 +71,7 @@ const metaLine = computed(() => {
       <ElevationProfile
         v-if="ride.elevationProfile?.length"
         :samples="ride.elevationProfile"
-        class="absolute inset-x-0 bottom-0 h-12 pointer-events-none"
+        class="pointer-events-none absolute inset-x-0 bottom-0 h-12"
       />
 
       <div class="relative flex flex-col gap-2">

--- a/src/components/cycling/RouteMap.vue
+++ b/src/components/cycling/RouteMap.vue
@@ -35,7 +35,7 @@ const fitted = computed(() =>
       loading="lazy"
       :width="TILE_SIZE"
       :height="TILE_SIZE"
-      class="absolute max-w-none grayscale-[.9] contrast-[.92] opacity-85 dark:opacity-70 dark:invert"
+      class="absolute max-w-none opacity-85 contrast-[.92] grayscale-[.9] dark:opacity-70 dark:invert"
       :style="{ left: `${tile.left}px`, top: `${tile.top}px` }"
     />
     <svg

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -12,9 +12,12 @@ export interface Props {
 const { frontmatter } = Astro.props;
 ---
 
-<Layout title={`${frontmatter.title} | ${SITE.title}`} sourcePath="src/pages/about.md">
+<Layout
+  title={`${frontmatter.title} | ${SITE.title}`}
+  sourcePath="src/pages/about.md"
+>
   <main id="main-content" class="mt-8">
-    <section id="about" class="page-column app-prose mb-28 prose-img:border-0">
+    <section id="about" class="app-prose page-column mb-28 prose-img:border-0">
       <h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>
       <slot />
     </section>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -72,7 +72,7 @@ const allPosts = posts.map(({ data: { title }, id, filePath }) => ({
   filePath,
 }));
 
-const currentPostIndex = allPosts.findIndex(a => a.id === post.id);
+const currentPostIndex = allPosts.findIndex((a) => a.id === post.id);
 
 const prevPost = currentPostIndex !== 0 ? allPosts[currentPostIndex - 1] : null;
 const nextPost =
@@ -108,7 +108,7 @@ const nextPost =
     <hr class="my-8 border-dashed" />
 
     <ul class="mt-4 mb-8 sm:my-8">
-      {tags.map(tag => <Tag tag={kebabcase(tag)} tagName={tag} />)}
+      {tags.map((tag) => <Tag tag={kebabcase(tag)} tagName={tag} />)}
     </ul>
 
     <BackToTopButton />
@@ -197,7 +197,7 @@ const nextPost =
    *  allowing sharing of sections easily */
   function addHeadingLinks() {
     const headings = Array.from(
-      document.querySelectorAll("h2, h3, h4, h5, h6")
+      document.querySelectorAll("h2, h3, h4, h5, h6"),
     );
     for (const heading of headings) {
       heading.classList.add("group");
@@ -268,6 +268,6 @@ const nextPost =
 
   /* Go to page start after page swap */
   document.addEventListener("astro:after-swap", () =>
-    window.scrollTo({ left: 0, top: 0, behavior: "instant" })
+    window.scrollTo({ left: 0, top: 0, behavior: "instant" }),
   );
 </script>

--- a/src/pages/activity/code.astro
+++ b/src/pages/activity/code.astro
@@ -26,8 +26,16 @@ try {
 }
 ---
 
-<Layout title={`Code | ${SITE.title}`} description="My public GitHub activity." ogImage="/activity/code/og.png" sourcePath="src/pages/activity/code.astro">
-  <Main pageTitle="Code" pageDesc="This page summarizes my GitHub activity by last contribution to each repository. It is an index of software projects I work on in public.">
+<Layout
+  title={`Code | ${SITE.title}`}
+  description="My public GitHub activity."
+  ogImage="/activity/code/og.png"
+  sourcePath="src/pages/activity/code.astro"
+>
+  <Main
+    pageTitle="Code"
+    pageDesc="This page summarizes my GitHub activity by last contribution to each repository. It is an index of software projects I work on in public."
+  >
     <section class="page-column">
       <ActivityTimeline
         client:load

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -31,11 +31,14 @@ const months = [
 ];
 ---
 
-<Layout title={`Archives | ${SITE.title}`} sourcePath="src/pages/archives/index.astro">
+<Layout
+  title={`Archives | ${SITE.title}`}
+  sourcePath="src/pages/archives/index.astro"
+>
   <Main pageTitle="Archives" pageDesc="All the articles I've archived.">
     {
       Object.entries(
-        Object.groupBy(posts, post => post.data.pubDatetime.getFullYear())
+        Object.groupBy(posts, (post) => post.data.pubDatetime.getFullYear()),
       )
         .toSorted(([yearA], [yearB]) => Number(yearB) - Number(yearA))
         .map(([year, yearGroup = []]) => (
@@ -43,9 +46,10 @@ const months = [
             <span class="text-2xl font-bold">{year}</span>
             <sup class="text-sm">{yearGroup.length}</sup>
             {Object.entries(
-              Object.groupBy(yearGroup, post =>
-                post.data.pubDatetime.getMonth() + 1
-              )
+              Object.groupBy(
+                yearGroup,
+                (post) => post.data.pubDatetime.getMonth() + 1,
+              ),
             )
               .toSorted(([monthA], [monthB]) => Number(monthB) - Number(monthA))
               .map(([month, monthGroup = []]) => (
@@ -59,13 +63,13 @@ const months = [
                       .toSorted(
                         (a, b) =>
                           Math.floor(
-                            new Date(b.data.pubDatetime).getTime() / 1000
+                            new Date(b.data.pubDatetime).getTime() / 1000,
                           ) -
                           Math.floor(
-                            new Date(a.data.pubDatetime).getTime() / 1000
-                          )
+                            new Date(a.data.pubDatetime).getTime() / 1000,
+                          ),
                       )
-                      .map(data => (
+                      .map((data) => (
                         <Card {...data} />
                       ))}
                   </ul>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,17 +11,28 @@ const sortedPosts = getSortedPosts(posts);
 const featuredPosts = sortedPosts.filter(({ data }) => data.featured);
 ---
 
-<Layout description="Programmer, cyclist, and photographer." sourcePath="src/pages/index.astro">
+<Layout
+  description="Programmer, cyclist, and photographer."
+  sourcePath="src/pages/index.astro"
+>
   <main id="main-content" data-layout="index">
     <section id="hero" class="page-column pt-8 pb-6 text-center">
       <img
         src="/images/ben-drucker-sq.png"
         srcset="/images/ben-drucker-sq.png 1x, /images/ben-drucker-sq@2x.png 2x"
         alt="Ben Drucker"
-        class="w-32 h-32 rounded-lg mx-auto mb-6"
+        class="mx-auto mb-6 h-32 w-32 rounded-lg"
       />
       <p>
-        <LinkButton href="/activity/code" class="underline decoration-dashed underline-offset-4">Programmer</LinkButton>, <LinkButton href="https://www.strava.com/athletes/5723594" class="underline decoration-dashed underline-offset-4">cyclist</LinkButton>, and photographer, living in San Francisco.
+        <LinkButton
+          href="/activity/code"
+          class="underline decoration-dashed underline-offset-4"
+          >Programmer</LinkButton
+        >, <LinkButton
+          href="https://www.strava.com/athletes/5723594"
+          class="underline decoration-dashed underline-offset-4"
+          >cyclist</LinkButton
+        >, and photographer, living in San Francisco.
       </p>
     </section>
 
@@ -31,7 +42,7 @@ const featuredPosts = sortedPosts.filter(({ data }) => data.featured);
           <section id="featured" class="page-column pt-12 pb-6">
             <h2 class="text-2xl font-semibold tracking-wide">Featured</h2>
             <ul>
-              {featuredPosts.map(data => (
+              {featuredPosts.map((data) => (
                 <Card variant="h3" {...data} />
               ))}
             </ul>
@@ -39,7 +50,6 @@ const featuredPosts = sortedPosts.filter(({ data }) => data.featured);
         </>
       )
     }
-
   </main>
 </Layout>
 

--- a/src/pages/posts/page/[...page].astro
+++ b/src/pages/posts/page/[...page].astro
@@ -18,10 +18,13 @@ export const getStaticPaths = (async ({ paginate }) => {
 const { page } = Astro.props;
 ---
 
-<Layout title={`Posts | ${SITE.title}`} sourcePath="src/pages/posts/page/[...page].astro">
+<Layout
+  title={`Posts | ${SITE.title}`}
+  sourcePath="src/pages/posts/page/[...page].astro"
+>
   <Main pageTitle="Posts" pageDesc="All the articles I've posted.">
     <ul>
-      {page.data.map(data => <Card {...data} />)}
+      {page.data.map((data) => <Card {...data} />)}
     </ul>
   </Main>
 

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -32,7 +32,10 @@ const { tag } = params;
 const { page, tagName } = Astro.props;
 ---
 
-<Layout title={`Tag: ${tagName} | ${SITE.title}`} sourcePath="src/pages/tags/[tag]/[...page].astro">
+<Layout
+  title={`Tag: ${tagName} | ${SITE.title}`}
+  sourcePath="src/pages/tags/[tag]/[...page].astro"
+>
   <Main
     pageTitle={[`Tag:`, `${tagName}`]}
     titleTransition={tag}
@@ -47,7 +50,7 @@ const { page, tagName } = Astro.props;
       <span>All tags</span>
     </LinkButton>
     <ul>
-      {page.data.map(data => <Card {...data} />)}
+      {page.data.map((data) => <Card {...data} />)}
     </ul>
   </Main>
 

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,4 +1,4 @@
-@plugin '@tailwindcss/typography';
+@plugin "@tailwindcss/typography";
 
 @layer base {
   /* ===== Override default Tailwind Typography styles ===== */


### PR DESCRIPTION
`prettier-plugin-astro` and `prettier-plugin-tailwindcss` sit in `devDependencies`, but no config file registers them. Prettier 3 doesn't autoload plugins, so both have been inert.

CI never caught it because `prettier --check .` drops `.astro` from its directory walk silently rather than erroring. Checking one explicitly is what surfaces it:

```
$ npx prettier --check src/layouts/Layout.astro
[error] No parser could be inferred for file ".../src/layouts/Layout.astro"
```

Adds `.prettierrc.json` registering both plugins with an `*.astro` parser override. 25 files format for the first time: 13 `.astro`, 11 `.vue` (Tailwind class sorting), and `typography.css` (quote normalization to match `global.css`).

Two details that aren't obvious from the diff:

- `tailwindStylesheet` is required under Tailwind v4. Without it the sorter can't resolve the theme, so it never sees the custom utilities `global.css` defines through `@theme inline`.
- `prettier-plugin-tailwindcss` has to be listed last, since it wraps the other plugin's printer.

## Verifying the Re-Sort

A repo-wide class re-sort is worth more than a visual skim, so it was checked mechanically at three levels.

**Source.** Extracted every `class`, `:class`, and `class:list` value from all 24 changed `.astro`/`.vue` files and compared class tokens per file before and after. Identical everywhere, so the change reorders and never adds, drops, or alters a class.

**Generated CSS.** Built the tree before and after in the same directory, to keep the build path out of the chunk hashes. Every `_astro/*.css` bundle is byte-identical, meaning Tailwind emitted exactly the same utilities.

**Rendered HTML.** All 17 prerendered HTML files are identical once class attribute order is normalized.

The remaining build differences are all identifiers rather than content: a Vue scoped-style hash (`data-v-*`, derived from component source), the content-hash filenames that cascade from it, and the nondeterministic build ID in `server/entry.mjs`.

## Pre-Existing Local Failure

`astro check` reports 10 `Property … does not exist on type 'Env'` errors across `workers/strava/main.ts` and `src/pages/photos/[...key].ts`. They reproduce unchanged on the base commit, and come from a local wrangler generating a narrower `Env` than the one this repo builds against, so this branch leaves them alone.

