### PR TITLE
ci: drop the story book PR comment

### DIFF
--- a/.claude/skills/component-stories/SKILL.md
+++ b/.claude/skills/component-stories/SKILL.md
@@ -7,8 +7,8 @@ paths: src/**/*.story.vue
 # Component Stories
 
 Stories are reviewed from a phone. Every pull request deploys the book to a
-Cloudflare preview alias and comments the link, so the reader has no checkout,
-no dev server, and a 390px viewport. That reader is the audience.
+Cloudflare preview alias, linked from the PR's deployments, so the reader has no
+checkout, no dev server, and a 390px viewport. That reader is the audience.
 
 ## Current API
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,6 @@ jobs:
     permissions:
       contents: read
       deployments: write
-      pull-requests: write
     outputs:
       www-preview-url: ${{ steps.set-outputs.outputs.www-preview-url }}
     strategy:
@@ -179,17 +178,6 @@ jobs:
           env: ${{ steps.deployment.outputs.env }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           env_url: ${{ github.event_name == 'pull_request' && steps.extract-url.outputs.alias-url || (matrix.path == '.' && steps.extract-deployment-url.outputs.formatted-url || '') }}
-
-      # A deployment's URL is buried in the PR timeline on a phone. The story
-      # book is meant to be reviewed from one, so its link gets a comment.
-      - name: "💬 Link the story book"
-        if: github.event_name == 'pull_request' && matrix.name == 'stories' && steps.extract-url.outputs.alias-url != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PREVIEW_URL: ${{ steps.extract-url.outputs.alias-url }}
-        run: |
-          gh pr comment "${{ github.event.number }}" --edit-last --create-if-none --body \
-            "📖 **[Component stories]($PREVIEW_URL)** · \`${GITHUB_SHA::7}\`"
 
       - name: "📤 Set job outputs"
         id: set-outputs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,11 @@ Tailwind, and the `@` alias. `src/histoire.setup.ts` imports `global.css` and
 mirrors Histoire's dark-mode class onto `data-theme`, so stories render in the
 site's real light and dark palettes.
 
-Every pull request deploys the story book to a Cloudflare preview alias and
-comments the link, so a component can be reviewed from a phone with nothing
-checked out. `workers/stories/wrangler.toml` serves `.histoire/dist` with a
-single-page-application fallback, since a story deep link has no HTML of its own.
+Every pull request deploys the story book to a Cloudflare preview alias,
+reachable from the PR's deployments, so a component can be reviewed from a phone
+with nothing checked out. `workers/stories/wrangler.toml` serves `.histoire/dist`
+with a single-page-application fallback, since a story deep link has no HTML of
+its own.
 
 Histoire hides its side panel below 640px, so a story declares its controls once
 in `src/stories/controls.ts` terms and renders them through both


### PR DESCRIPTION
Removes the bot comment that linked each PR's story book preview. The stories worker deploys as its own environment, so its preview URL already sits in the PR's deployments alongside the www preview, with the same link button. The comment repeated that link and nothing else.

The `pull-requests: write` grant on the `cloudflare` job goes with it, since the comment was the only thing that used it.
