### PR TITLE
ci: check D1 migrations on pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,31 @@ jobs:
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           command: d1 migrations apply bendrucker-activity --remote
 
+      # The apply step above never runs on a pull request, so nothing exercised
+      # the D1 token until merge. `list` takes the same auth and write path as
+      # `apply` without touching the schema, and prints what a merge would run.
+      - name: "🗃️ List unapplied D1 migrations"
+        id: list
+        if: github.event_name == 'pull_request'
+        uses: cloudflare/wrangler-action@v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations list bendrucker-activity --remote
+
+      - name: "📋 Summarize pending migrations"
+        if: github.event_name == 'pull_request'
+        env:
+          OUTPUT: ${{ steps.list.outputs.command-output }}
+        run: |
+          {
+            echo "## D1 migrations"
+            echo
+            echo '```'
+            printf '%s\n' "$OUTPUT" | sed 's/\x1b\[[0-9;]*m//g'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   cloudflare:
     name: ${{ matrix.name }}
     needs: migrate


### PR DESCRIPTION
The `migrate` job's `if` admits pull requests, but its only substantive step is gated on `push`. A PR run does `checkout`, `setup-node`, `npm ci` and stops. It never contacts Cloudflare, so it always passes.

That hid a broken credential. `CLOUDFLARE_API_TOKEN` predated the D1 database and lacked D1 scope, so `d1 migrations apply` returned a 7403 on every push to `main` from #586 onward. The site did not deploy for twelve days while the PR path reported nothing, because nothing on it touched the token.

Adds a blocking `d1 migrations list bendrucker-activity --remote` step on pull requests, writing its output to the job summary.

## Choice of `list`

`list` walks the same path `apply` does short of executing migration SQL: same auth, same database resolution from `[[d1_databases]]`, same `/query` endpoint. It also reports which files are pending, which a bare credential probe cannot.

It opens with `CREATE TABLE IF NOT EXISTS "d1_migrations"` because wrangler's `initMigrationsTable` runs unconditionally before the read. Wrangler decides that, and exposes no flag to skip it. Against the table that has existed since `0001` it is a no-op.

The write is not what catches a bad token. The incident's 7403 was service-level D1 denial, so a read-only call would have failed identically. A token holding D1 Read but not Write is the case the write might discriminate, and that is untested: both statements hit the same endpoint.

## Scope

Not gated on a `migrations/` diff. Exercising the credential continuously matters more than checking migration files, and a diff gate would fire only on the rare PR that adds one.

## Ruleset Sequencing

`migrations` is not yet a required check, and this PR leaves the ruleset alone. A required context that has never reported can leave PRs pending indefinitely, so that edit comes after this merges and the context reports on `main`.

Dependabot stays safe when it does:

- `migrate` carries `if: github.actor != 'dependabot[bot]'`, and a job skipped by a conditional still produces a check run.
- #608, #607, and #606 all show `migrations` as `completed/skipped`, which satisfies a required context.
- Indefinite pending needs path or branch filtering, where no check run exists at all. `deploy.yml` has neither.

## Verification

Ran against production both ways. With `main` current the summary reads `✅ No migrations to apply!`; with a throwaway `0006_verify.sql` on the branch it listed that file instead. Removed the throwaway before marking this ready.

Wrangler emits ANSI even when stdout is not a TTY. Every sequence is SGR, so the `sed` strips all of them. The value reaches the shell via `env:` rather than `${{ }}`, matching `🔗 Extract preview URL`.
